### PR TITLE
feat(trace): add `node_red.flow.name` span attribute

### DIFF
--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -24,6 +24,7 @@ const jmespath = require('jmespath')
 
 const ATTR_MSG_ID = 'node_red.msg.id'
 const ATTR_FLOW_ID = 'node_red.flow.id'
+const ATTR_FLOW_NAME = 'node_red.flow.name'
 const ATTR_NODE_ID = 'node_red.node.id'
 const ATTR_NODE_TYPE = 'node_red.node.type'
 const ATTR_NODE_NAME = 'node_red.node.name'
@@ -225,6 +226,7 @@ function createSpan (tracer, msg, nodeDefinition, node, isNotTraced) {
     const commonAttributes = {
       [ATTR_MSG_ID]: msgId,
       [ATTR_FLOW_ID]: nodeDefinition.z,
+      [ATTR_FLOW_NAME]: nodeDefinition._flow?.flow?.label ?? '',
       [ATTR_NODE_ID]: nodeDefinition.id,
       [ATTR_NODE_TYPE]: nodeDefinition.type,
       [ATTR_NODE_NAME]: nodeDefinition.name,


### PR DESCRIPTION
**Summary**

Adds `node_red.flow.name` attribute to all spans by resolving the flow tab label from the node's `_flow.flow.label` reference.

**Motivation**

Flow name is essential for practical observability in Node-RED:

- Typical setups have many flows, often with identically named nodes — without the flow name there's no way to tell them apart
- Flow IDs are opaque hashes, not something you can work with visually
- Being able to filter and group by flow name (e.g. in Grafana) makes a real difference for dashboards

**Implementation notes**

- Uses `nodeDefinition._flow.flow.label` — an internal (non-enumerable) property on node objects, available since Node-RED 0.20 (2019)
- Degrades to empty string if not available for any reason

The changes are tested and we are using them in our large-scale Node-RED v4.0.9 instance.