### PR TITLE
fix(trace): one trace per flow execution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .eslintrc.json
 .github
 docs
+test
 node-red-contrib-opentelemetry-*.tgz

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
 - based on [OpenTelemetry JavaScript framework](https://github.com/open-telemetry/opentelemetry-js) and [Node-RED messaging hooks](https://nodered.org/docs/api/hooks/messaging):
   - create spans on `onSend(source)` and `postDeliver(destination)` events,
   - end spans on `onComplete` and `postDeliver(source)` events.
+- **one trace per flow execution**: every node a message reaches is a span below a single run
+  span, whatever the message identifier changes along the way (see [Traces and runs](#traces-and-runs)),
+- continues the caller trace when the entry node receives a [W3C trace context](https://www.w3.org/TR/trace-context/#design-overview)
+  (`http in` headers, `mqtt in` v5 user properties, `amqp-in` headers),
 - trace includes:
+  - run id,
   - message id,
   - flow id,
   - node id,
@@ -29,6 +34,31 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
 ![Example spans in JaegerUI](https://raw.githubusercontent.com/nioc/node-red-contrib-opentelemetry/master/docs/Screenshot_01.png "Example spans")
 
 ![Example spans to metrics in Grafana](https://raw.githubusercontent.com/nioc/node-red-contrib-opentelemetry/master/docs/Screenshot_02.png "Example spans to metrics")
+
+### Traces and runs
+
+A trace stands for one execution of your flow. The first node to emit a message opens a **run
+span**, every node the message reaches becomes a child span, and the run span ends when the last
+of those node spans ends.
+
+Node-RED gives a fresh `_msgid` to every message object a node emits (a `function` node
+returning `{payload: ...}` instead of the message it received, a `split` node, a `join` node,
+...). To keep those in the same trace, the run is carried on the message in the
+`otelRootMsgId` property, which you will therefore see on messages in the debug sidebar.
+
+Two situations deliberately produce more than one trace, following the
+[messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/):
+
+- a node that acknowledges a message and emits later (`delay`, `trigger`, a rate limiter) hands
+  over to a new run, linked to the one it came from with a span link
+  (`node_red.link.type: continuation`),
+- a message published to a broker and consumed by another flow is a run of its own, correlated
+  through the propagated trace context.
+
+Nodes that never report completion (`tcp in`, `server-events`, ...) get their span closed once
+the message they created has been dispatched. A run left unfinished past the configured
+`timeout` is closed by a sweep, and the node spans still open are ended and flagged with
+`node_red.span.incomplete` instead of being dropped.
 
 ### Metrics
 
@@ -82,7 +112,7 @@ As with every [node installation](https://nodered.org/docs/user-guide/runtime/ad
   - define an optional root span prefix (will be added in Node-RED root span name),
   - define nodes that should not send traces (using comma-separated list like `debug,catch`),
   - define nodes that should propagate [W3C trace context](https://www.w3.org/TR/trace-context/#design-overview) (in http request headers, using comma-separated list like `http request,my-custom-node`),
-  - define time in seconds after which an unmodified message will be ended and deleted,
+  - define time in seconds after which a run with no activity is considered abandoned and closed,
   - define custom attributes you want to send (optionally).
 
 ### Metrics

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
   (`http in` headers, `mqtt in` v5 user properties, `amqp-in` headers),
 - trace includes:
   - run id,
+  - type of the node that triggered the run (`node_red.trigger.type`, on the run span),
   - message id,
   - flow id,
   - node id,
@@ -39,7 +40,8 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
 
 A trace stands for one execution of your flow. The first node to emit a message opens a **run
 span**, every node the message reaches becomes a child span, and the run span ends when the last
-of those node spans ends.
+of those node spans ends. The run span carries `node_red.trigger.type`, the type of the node
+that set the run off, so a collector can route or filter on it without reading the node spans.
 
 Node-RED gives a fresh `_msgid` to every message object a node emits (a `function` node
 returning `{payload: ...}` instead of the message it received, a `split` node, a `join` node,

--- a/lib/opentelemetry-node.html
+++ b/lib/opentelemetry-node.html
@@ -189,7 +189,7 @@ RED.nodes.registerType('OpenTelemetry', {
     <label for="node-input-propagateHeadersTypes"><i class="fa fa-suitcase"></i> Propagate</label>
     <input type="text" id="node-input-propagateHeadersTypes" placeholder="mycustomnode,othernode">
   </div>
-  <div class="form-row" title="Time in seconds after which an unmodified message will be ended and deleted">
+  <div class="form-row" title="Time in seconds after which a run with no activity is considered abandoned and closed">
     <label for="node-input-timeout"><i class="fa fa-hourglass"></i> Timeout</label>
     <input type="number" id="node-input-timeout" placeholder="10">
   </div>
@@ -209,7 +209,9 @@ RED.nodes.registerType('OpenTelemetry', {
 <script type="text/html" data-help-name="OpenTelemetry">
   <p>Send Node-RED traces to OpenTelemetry collector (like Jaeger or Zipkin).</p>
   <h3>Details</h3>
-  <p>With this node enabled, each message will generate a trace composed of the traces (spans) of each node traversed.</p>
+  <p>With this node enabled, each execution of a flow will generate a trace composed of the traces (spans) of each node traversed.</p>
+  <p>The node that starts an execution opens the run span, every node the message reaches is a span below it, and the run span ends once the last of them ends. Messages created along the way (by a <code>function</code>, <code>split</code> or <code>join</code> node for example) stay in the same trace: the run is carried in the <code>otelRootMsgId</code> message property. When the entry node receives a trace context from outside Node-RED, the run continues the caller trace instead of starting a new one.</p>
+  <p>A node that acknowledges a message and emits it later (<code>delay</code>, <code>trigger</code>, ...) hands over to a new trace, linked to the one it came from.</p>
   <p>You must set:<ul>
     <li>the <code>url</code> of the exporter,</li>
     <li>the <code>service</code> name displayed in your visualization tool,</li>

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -47,6 +47,8 @@ const ATTR_NODE_ID = 'node_red.node.id'
 const ATTR_NODE_TYPE = 'node_red.node.type'
 const ATTR_NODE_NAME = 'node_red.node.name'
 const ATTR_IS_MESSAGE_CREATION = 'node_red.msg.new'
+/** Type of the node that started the run, on the run span only */
+const ATTR_TRIGGER_TYPE = 'node_red.trigger.type'
 const ATTR_SPAN_INCOMPLETE = 'node_red.span.incomplete'
 const ATTR_LINK_TYPE = 'node_red.link.type'
 
@@ -373,6 +375,9 @@ function createRun (tracer, msg, nodeDefinition, predecessorRunId) {
   const rootSpan = tracer.startSpan(_rootPrefix + (nodeDefinition.name || nodeDefinition.type), {
     attributes: {
       [ATTR_IS_MESSAGE_CREATION]: true,
+      // what set this run off, kept on the run span so a collector can route or filter on it
+      // without looking at the node spans below
+      [ATTR_TRIGGER_TYPE]: nodeDefinition.type,
       ...getCommonAttributes(nodeDefinition, msg, runId),
     },
     kind: getSpanKind(nodeDefinition.type),

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -94,6 +94,13 @@ const nodeStates = new Map()
  */
 const endedRuns = new Map()
 
+/**
+ * Identifier of the OpenTelemetry node owning the runtime hooks. Hook labels are global to the
+ * Node-RED runtime, so only one node can register them.
+ * @type {string|null}
+ */
+let activeNodeId = null
+
 let runSequence = 0
 let _isLogging = false
 let _rootPrefix = ''
@@ -696,19 +703,32 @@ module.exports = function (RED) {
 
     // get config
     const { url, protocol, serviceName, rootPrefix, ignoredTypes, propagateHeadersTypes, isLogging, timeout, attributeMappings } = config
-    const ignoredTypesList = ignoredTypes.split(',').map(key => key.trim())
-    const propagateHeadersTypesList = propagateHeadersTypes.split(',').map(key => key.trim())
-    _isLogging = isLogging
-    _rootPrefix = rootPrefix
-    _timeout = timeout * 1000
-    _attributeMappings = attributeMappings
+    const node = this
 
     // check config
     if (!url) {
       this.status({ fill: 'red', shape: 'ring', text: 'invalid configuration' })
       return
     }
-    const node = this
+
+    // The `.otel` hook label is global to the Node-RED runtime, so a single node can own the
+    // hooks. A second one stays inactive rather than failing the deploy with
+    // "Hook onSend.otel already registered", and leaves the active node's settings alone.
+    if (activeNodeId !== null && activeNodeId !== node.id) {
+      node.warn(`OpenTelemetry tracing is already handled by node "${activeNodeId}", this node stays inactive. One OpenTelemetry node covers every flow, wherever it is placed.`)
+      node.status({ fill: 'grey', shape: 'ring', text: 'inactive, another OTEL node is active' })
+      return
+    }
+    // reclaim hooks left behind by an instance whose close handler did not run
+    RED.hooks.remove('*.otel')
+    activeNodeId = node.id
+
+    const ignoredTypesList = ignoredTypes.split(',').map(key => key.trim())
+    const propagateHeadersTypesList = propagateHeadersTypes.split(',').map(key => key.trim())
+    _isLogging = isLogging
+    _rootPrefix = rootPrefix
+    _timeout = timeout * 1000
+    _attributeMappings = attributeMappings
 
     // create tracer
     let spanProcessor
@@ -844,6 +864,7 @@ module.exports = function (RED) {
         intervalId = null
       }
       RED.hooks.remove('*.otel')
+      activeNodeId = null
       runs.clear()
       nodeStates.clear()
       endedRuns.clear()

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -647,7 +647,9 @@ function endSpan (msg, error, nodeDefinition) {
       } else {
         span.recordException(error)
       }
-      span.setStatus({ code: SpanStatusCode.ERROR, message: error })
+      // the SDK drops a status message that is not a string, and a node that throws reports an
+      // Error object here, so the reason would be lost
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error instanceof Error ? error.message : String(error) })
       run.rootSpan.setStatus({ code: SpanStatusCode.ERROR })
     }
     const localAttributes = parseAttribute(true, msg, nodeDefinition.z, nodeDefinition.type)

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -20,27 +20,81 @@ const jmespath = require('jmespath')
 /**
  * @typedef {import('@opentelemetry/api').Tracer} Tracer
  * @typedef {import('@opentelemetry/api').Span} Span
+ * @typedef {import('@opentelemetry/api').Context} Context
+ *
+ * @typedef {object} Run A single flow execution: one root span and the node spans below it
+ * @property {string} id
+ * @property {Span} rootSpan
+ * @property {Context} ctx Context holding the root span, used as parent of every node span
+ * @property {Map<string, Span>} spans Open node spans, keyed by `<msgId>#<nodeId>`
+ * @property {Set<string>} ignored Span keys of nodes excluded from tracing
+ * @property {Set<string>} entrySpans Span keys of nodes that emitted a message without receiving one
+ * @property {number} pending Number of open node spans (the root ends when this reaches 0)
+ * @property {number} updateTimestamp
+ * @property {boolean} ended
+ *
+ * @typedef {object} NodeState What a node is currently working on
+ * @property {string} runId
+ * @property {string} msgId
+ * @property {number} inFlight
  */
 
 const ATTR_MSG_ID = 'node_red.msg.id'
+const ATTR_RUN_ID = 'node_red.run.id'
 const ATTR_FLOW_ID = 'node_red.flow.id'
 const ATTR_FLOW_NAME = 'node_red.flow.name'
 const ATTR_NODE_ID = 'node_red.node.id'
 const ATTR_NODE_TYPE = 'node_red.node.type'
 const ATTR_NODE_NAME = 'node_red.node.name'
 const ATTR_IS_MESSAGE_CREATION = 'node_red.msg.new'
-const ORPHAN_NODE_TYPES = ['switch', 'rbe']
+const ATTR_SPAN_INCOMPLETE = 'node_red.span.incomplete'
+const ATTR_LINK_TYPE = 'node_red.link.type'
+
+/**
+ * Message property carrying the run identifier. Kept under its historical name so that
+ * flows and dashboards referring to it keep working; it now identifies the whole flow
+ * execution instead of only the message that entered a `split` node.
+ */
+const RUN_ID_PROPERTY = 'otelRootMsgId'
+
+/** Node types that emit messages without receiving one but whose span is closed elsewhere */
+const CORRELATED_ENTRY_TYPES = ['http in']
+
+/** How long the context of a finished run stays available for linking a continuation (ms) */
+const LINKABLE_RUN_RETENTION = 60000
+
+/** Upper bound on retained run contexts, so a busy instance cannot grow the map unchecked */
+const LINKABLE_RUN_LIMIT = 10000
+
 const fakeSpan = {
   end: () => {},
   recordException: () => {},
   setStatus: () => {},
   setAttribute: () => {},
+  setAttributes: () => {},
 }
+
 /**
- * The map of running parent spans, each message will be an entry, each span will be stored in its own spans map
- * @type {Map<string, {parentSpan: Span, spans: Map<string, Span>, updateTimestamp: number}>}
+ * Flow executions currently in progress, keyed by run id
+ * @type {Map<string, Run>}
  */
-const msgSpans = new Map()
+const runs = new Map()
+
+/**
+ * What each node is currently processing, used to attribute a newly created message to the
+ * run its emitting node belongs to (Node-RED mints a fresh `_msgid` for every message object
+ * a node emits that does not already have one).
+ * @type {Map<string, NodeState>}
+ */
+const nodeStates = new Map()
+
+/**
+ * Root span context of recently finished runs, so a continuation can be linked to it
+ * @type {Map<string, {spanContext: import('@opentelemetry/api').SpanContext, endTimestamp: number}>}
+ */
+const endedRuns = new Map()
+
+let runSequence = 0
 let _isLogging = false
 let _rootPrefix = ''
 let _timeout = 10
@@ -60,23 +114,140 @@ const propagator = new CompositePropagator({
 })
 
 /**
- * Get parent span id or current message id if there is none
- * @param {any} msg Message data to be used to retrieve the parent span id `otelRootMsgId`
- * @returns {string}
+ * Read the run identifier carried by a message
+ * @param {any} msg Message data
+ * @returns {string|undefined}
  */
-function getMsgId (msg) {
-  return msg.otelRootMsgId ? msg.otelRootMsgId : msg._msgid
+function getRunId (msg) {
+  // eslint-disable-next-line security/detect-object-injection
+  return msg[RUN_ID_PROPERTY]
 }
 
 /**
- * Return the span identifier for this node and message
- * @param {any} msg Message data to be used to retrieve the parent message id
- * @param {any} nodeDefinition Current node definition
+ * Carry the run identifier on a message, so the nodes it reaches join the same trace
+ * @param {any} msg Message data
+ * @param {string} runId Run identifier
+ */
+function setRunId (msg, runId) {
+  // eslint-disable-next-line security/detect-object-injection
+  msg[RUN_ID_PROPERTY] = runId
+}
+
+/**
+ * Read an attribute of a span being built
+ * @param {Span} span Span to read
+ * @param {string} attributeName One of the attribute names defined above
+ * @returns {string|number|boolean|undefined}
+ */
+function getSpanAttribute (span, attributeName) {
+  // eslint-disable-next-line security/detect-object-injection
+  return span?.attributes?.[attributeName]
+}
+
+/**
+ * Return the span key identifying a node span within a run
+ * @param {string} msgId Identifier of the message the node is processing
+ * @param {string} nodeId Node identifier
  * @returns {string}
  */
-function getSpanId (msg, nodeDefinition) {
-  const msgId = nodeDefinition.type === 'split' && msg.otelRootMsgId ? msg.otelRootMsgId : msg._msgid
-  return `${msgId}#${nodeDefinition.id}`
+function getSpanKey (msgId, nodeId) {
+  return `${msgId}#${nodeId}`
+}
+
+/**
+ * Find the key of an already open span for this node, tolerating a node that emitted a new
+ * message (and therefore a new `_msgid`) while it was processing another one
+ * @param {Run} run Run holding the span
+ * @param {any} msg Message data
+ * @param {string} nodeId Node identifier
+ * @returns {string|undefined} Span key, or undefined when this node has no open span
+ */
+function findSpanKey (run, msg, nodeId) {
+  const direct = getSpanKey(msg._msgid, nodeId)
+  if (run.spans.has(direct) || run.ignored.has(direct)) {
+    return direct
+  }
+  const state = nodeStates.get(nodeId)
+  if (state !== undefined) {
+    const viaNodeState = getSpanKey(state.msgId, nodeId)
+    if (run.spans.has(viaNodeState) || run.ignored.has(viaNodeState)) {
+      return viaNodeState
+    }
+  }
+  return undefined
+}
+
+/**
+ * Return the first candidate identifier matching a run still in progress
+ * @param {Array<string|undefined>} candidateIds Candidate run identifiers, most trusted first
+ * @returns {Run|undefined}
+ */
+function resolveRun (candidateIds) {
+  for (const candidateId of candidateIds) {
+    if (candidateId !== undefined && runs.has(candidateId)) {
+      return runs.get(candidateId)
+    }
+  }
+  return undefined
+}
+
+/**
+ * Map a Node-RED node type to a span kind
+ * @param {string} nodeType Node type (ex: `http in`, `function`)
+ * @returns {SpanKind}
+ */
+function getSpanKind (nodeType) {
+  switch (nodeType) {
+    case 'http in':
+    case 'tcp in':
+    case 'udp in':
+      return SpanKind.SERVER
+    case 'http request':
+    case 'tcp request':
+      return SpanKind.CLIENT
+    case 'mqtt in':
+    case 'amqp-in':
+    case 'websocket in':
+      return SpanKind.CONSUMER
+    case 'mqtt out':
+    case 'amqp-out':
+    case 'websocket out':
+      return SpanKind.PRODUCER
+    default:
+      return SpanKind.INTERNAL
+  }
+}
+
+/**
+ * Try to continue the trace of the caller, using the context carried by the incoming message
+ * @param {any} nodeDefinition Node receiving the message from outside Node-RED
+ * @param {any} msg Complete message data
+ * @returns {Context|undefined} Extracted context, or undefined when there is nothing to extract
+ */
+function extractIncomingContext (nodeDefinition, msg) {
+  try {
+    switch (nodeDefinition.type) {
+      case 'http in':
+        // trace context in incoming http request headers
+        return propagator.extract(context.active(), msg.req.headers, defaultTextMapGetter)
+      case 'mqtt in':
+        // trace context in incoming mqtt v5 user properties
+        if (msg.userProperties) {
+          return propagator.extract(context.active(), msg.userProperties, defaultTextMapGetter)
+        }
+        return undefined
+      case 'amqp-in':
+        // trace context in incoming amqp message headers
+        return propagator.extract(context.active(), msg.properties.headers, defaultTextMapGetter)
+      default:
+        return undefined
+    }
+  } catch (error) {
+    if (_isLogging) {
+      console.log(`No trace context extracted from ${nodeDefinition.type}: ${error.message}`)
+    }
+    return undefined
+  }
 }
 
 /**
@@ -90,7 +261,7 @@ function logEvent (node, eventType, event) {
     return
   }
   try {
-    let msg = `rootMsgId: ${getMsgId(event.msg)}, _msgId: ${event.msg._msgid}:`
+    let msg = `runId: ${getRunId(event.msg)}, _msgId: ${event.msg._msgid}:`
     if (event.source && event.source.node) {
       msg += ` src: ${event.source.node.type} ${event.source.node.id}`
     }
@@ -103,27 +274,6 @@ function logEvent (node, eventType, event) {
     console.log(`${eventType}: ${msg}`)
   } catch (error) {
     console.error(`An error occurred during logging ${eventType}`, error)
-  }
-}
-
-/**
- * Delete outdated message spans
- */
-function deleteOutdatedMsgSpans () {
-  const now = Date.now()
-  try {
-    for (const [msgId, msgSpan] of msgSpans) {
-      if (msgSpan.updateTimestamp < now - _timeout) {
-        // ending parent span and remove it
-        if (_isLogging) {
-          console.log(`Parent span "${msgSpan.parentSpan.name}" ${msgId} is outdated, ending`)
-        }
-        msgSpan.parentSpan.end(msgSpan.updateTimestamp)
-        msgSpans.delete(msgId)
-      }
-    }
-  } catch (error) {
-    console.error('An error occurred during span cleaning', error)
   }
 }
 
@@ -170,175 +320,274 @@ function parseAttribute (isAfter, data, flowId, nodeType) {
 }
 
 /**
+ * Span attributes shared by the root span and every node span
+ * @param {any} nodeDefinition Current node definition
+ * @param {any} msg Complete message data
+ * @param {string} runId Run identifier
+ * @returns {Record<string, string | number | boolean >}
+ */
+function getCommonAttributes (nodeDefinition, msg, runId) {
+  return {
+    [ATTR_RUN_ID]: runId,
+    [ATTR_MSG_ID]: msg._msgid,
+    [ATTR_FLOW_ID]: nodeDefinition.z,
+    [ATTR_FLOW_NAME]: nodeDefinition._flow?.flow?.label ?? '',
+    [ATTR_NODE_ID]: nodeDefinition.id,
+    [ATTR_NODE_TYPE]: nodeDefinition.type,
+    [ATTR_NODE_NAME]: nodeDefinition.name,
+  }
+}
+
+/**
+ * Start a new run: one root span standing for this flow execution, parented to the caller
+ * context when the entry node carries one, and linked to the run it continues when the
+ * message comes from an execution that already finished (an asynchronous hand-off).
+ * @param {Tracer} tracer Tracer used for creating spans
+ * @param {any} msg Complete message data
+ * @param {any} nodeDefinition Node starting the run
+ * @param {string|undefined} predecessorRunId Run this execution continues, if any
+ * @returns {Run}
+ */
+function createRun (tracer, msg, nodeDefinition, predecessorRunId) {
+  // a run is identified by the message that started it, kept unique so that a message sent
+  // again later cannot be mistaken for the run it originally belonged to
+  let runId = msg._msgid
+  if (runs.has(runId) || endedRuns.has(runId)) {
+    runId = `${msg._msgid}-${++runSequence}`
+  }
+  const now = Date.now()
+  const links = []
+  if (predecessorRunId !== undefined && endedRuns.has(predecessorRunId)) {
+    links.push({
+      context: endedRuns.get(predecessorRunId).spanContext,
+      attributes: { [ATTR_LINK_TYPE]: 'continuation' },
+    })
+  }
+  const rootSpan = tracer.startSpan(_rootPrefix + (nodeDefinition.name || nodeDefinition.type), {
+    attributes: {
+      [ATTR_IS_MESSAGE_CREATION]: true,
+      ...getCommonAttributes(nodeDefinition, msg, runId),
+    },
+    kind: getSpanKind(nodeDefinition.type),
+    links,
+  }, extractIncomingContext(nodeDefinition, msg) ?? context.active())
+  const run = {
+    id: runId,
+    rootSpan,
+    ctx: trace.setSpan(context.active(), rootSpan),
+    spans: new Map(),
+    ignored: new Set(),
+    entrySpans: new Set(),
+    pending: 0,
+    updateTimestamp: now,
+    ended: false,
+  }
+  runs.set(runId, run)
+  if (_isLogging) {
+    console.log(`=> Started run ${runId} on ${nodeDefinition.type}${links.length > 0 ? ` (linked to ${predecessorRunId})` : ''}`)
+  }
+  return run
+}
+
+/**
+ * Return the run this message belongs to, starting one when there is none in progress
+ * @param {Tracer} tracer Tracer used for creating spans
+ * @param {any} msg Complete message data
+ * @param {any} nodeDefinition Current node definition
+ * @param {Array<string|undefined>} candidateIds Candidate run identifiers, most trusted first
+ * @returns {Run}
+ */
+function getOrCreateRun (tracer, msg, nodeDefinition, candidateIds) {
+  const run = resolveRun(candidateIds)
+  if (run !== undefined) {
+    return run
+  }
+  // no run in progress: this message starts one, possibly continuing a finished run
+  const predecessorRunId = candidateIds.find((candidateId) => candidateId !== undefined && endedRuns.has(candidateId))
+  return createRun(tracer, msg, nodeDefinition, predecessorRunId)
+}
+
+/**
+ * End the root span of a run, keeping its context available for linking a continuation
+ * @param {Run} run Run to close
+ * @param {number} [endTime] Explicit end timestamp (used when closing an abandoned run)
+ */
+function finishRun (run, endTime) {
+  if (run.ended) {
+    return
+  }
+  run.ended = true
+  run.rootSpan.end(endTime)
+  endedRuns.set(run.id, {
+    spanContext: run.rootSpan.spanContext(),
+    endTimestamp: Date.now(),
+  })
+  if (endedRuns.size > LINKABLE_RUN_LIMIT) {
+    // insertion ordered, so this drops the oldest retained context
+    endedRuns.delete(endedRuns.keys().next().value)
+  }
+  runs.delete(run.id)
+  if (_isLogging) {
+    console.log(`=> Ended run ${run.id}`)
+  }
+}
+
+/**
+ * End a node span and close the run once its last node span is done
+ * @param {Run} run Run holding the span
+ * @param {string} spanKey Span key
+ * @param {number} [endTime] Explicit end timestamp
+ */
+function endChildSpan (run, spanKey, endTime) {
+  if (run.ignored.has(spanKey)) {
+    // not traced, and never counted as pending
+    run.ignored.delete(spanKey)
+    return
+  }
+  const span = run.spans.get(spanKey)
+  if (span === undefined) {
+    return
+  }
+  span.end(endTime)
+  run.spans.delete(spanKey)
+  run.entrySpans.delete(spanKey)
+  run.pending = Math.max(0, run.pending - 1)
+  run.updateTimestamp = Date.now()
+  if (run.pending === 0) {
+    finishRun(run)
+  }
+}
+
+/**
+ * Close runs left behind by nodes that never report completion. Node spans still open are
+ * ended (and flagged) instead of being dropped, so the trace keeps them.
+ */
+function sweepRuns () {
+  const now = Date.now()
+  try {
+    for (const [runId, run] of runs) {
+      if (run.updateTimestamp >= now - _timeout) {
+        continue
+      }
+      if (_isLogging) {
+        console.log(`Run ${runId} is outdated, ending ${run.spans.size} unfinished span(s)`)
+      }
+      for (const [spanKey, span] of run.spans) {
+        span.setAttribute(ATTR_SPAN_INCOMPLETE, true)
+        span.end(run.updateTimestamp)
+        run.spans.delete(spanKey)
+      }
+      run.pending = 0
+      run.rootSpan.setAttribute(ATTR_SPAN_INCOMPLETE, true)
+      finishRun(run, run.updateTimestamp)
+    }
+    for (const [runId, endedRun] of endedRuns) {
+      if (endedRun.endTimestamp < now - LINKABLE_RUN_RETENTION) {
+        endedRuns.delete(runId)
+      }
+    }
+  } catch (error) {
+    console.error('An error occurred during run cleaning', error)
+  }
+}
+
+/**
  * Create a span for this node and message
  * @param {Tracer} tracer Tracer used for creating spans
  * @param {any} msg Complete message data
  * @param {any} nodeDefinition Current node definition
- * @param {any} node OTEL node (for using Node-RED utilities)
- * @param {boolean} isNotTraced Is the node should be traced?
- * @returns {Span|undefined} Created span
+ * @param {Array<string|undefined>} candidateRunIds Candidate run identifiers, most trusted first
+ * @param {boolean} isNotTraced Should the node be left untraced?
+ * @param {boolean} isEntry Is the node emitting a message it never received?
+ * @returns {Span|undefined} Created (or already open) span
  */
-function createSpan (tracer, msg, nodeDefinition, node, isNotTraced) {
+function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, isEntry) {
   try {
-    // check and get message id (handle root message id for splitted parts)
-    const msgId = getMsgId(msg)
-    if (msgId === undefined) {
+    if (msg === undefined || msg === null || msg._msgid === undefined) {
       return
     }
-    // check and get span id (msg id and node id)
-    const spanId = getSpanId(msg, nodeDefinition)
-    if (msgSpans.has(msgId) && msgSpans.get(msgId).spans.has(spanId)) {
-      return
+    const run = getOrCreateRun(tracer, msg, nodeDefinition, candidateRunIds)
+    // Carry the run on the message, so every node downstream joins the same trace even when a
+    // node emits a brand new message object (Node-RED gives those a fresh `_msgid`). This also
+    // overwrites the run of a message emitted again long after its original run finished.
+    setRunId(msg, run.id)
+
+    // an open span for this node is reused, so a node emitting several messages gets one span
+    const openSpanKey = findSpanKey(run, msg, nodeDefinition.id)
+    if (openSpanKey !== undefined) {
+      return run.spans.get(openSpanKey) ?? fakeSpan
     }
-
-    // define context variables
-    const spanName = nodeDefinition.name || nodeDefinition.type
-    const now = Date.now()
-    let parentSpan, ctx, kind
-
-    // try to set span kind
-    switch (nodeDefinition.type) {
-      case 'http in':
-      case 'tcp in':
-      case 'udp in':
-        kind = SpanKind.SERVER
-        break
-      case 'http request':
-      case 'tcp request':
-        kind = SpanKind.CLIENT
-        break
-      case 'mqtt in':
-      case 'amqp-in':
-      case 'websocket in':
-        kind = SpanKind.CONSUMER
-        break
-      case 'mqtt out':
-      case 'amqp-out':
-      case 'websocket out':
-        kind = SpanKind.PRODUCER
-        break
-      default:
-        kind = SpanKind.INTERNAL
-        break
-    }
-
-    // prepare common attributes
-    const commonAttributes = {
-      [ATTR_MSG_ID]: msgId,
-      [ATTR_FLOW_ID]: nodeDefinition.z,
-      [ATTR_FLOW_NAME]: nodeDefinition._flow?.flow?.label ?? '',
-      [ATTR_NODE_ID]: nodeDefinition.id,
-      [ATTR_NODE_TYPE]: nodeDefinition.type,
-      [ATTR_NODE_NAME]: nodeDefinition.name,
-    }
-
-    // handle context
-    if (msgSpans.has(msgId)) {
-      // get (parent) message context
-      ctx = trace.setSpan(context.active(), msgSpans.get(msgId).parentSpan)
-    } else {
-      if (nodeDefinition.type === 'http in') {
-        // try to get trace context in incoming http request headers
-        ctx = propagator.extract(context.active(), msg.req.headers, defaultTextMapGetter)
-      } else if (nodeDefinition.type === 'mqtt in' && msg.userProperties) {
-        // try to get trace context in incoming mqtt v5 user properties
-        ctx = propagator.extract(context.active(), msg.userProperties, defaultTextMapGetter)
-      } else if (nodeDefinition.type === 'amqp-in') {
-        // try to get trace context in incoming ampq message headers
-        ctx = propagator.extract(context.active(), msg.properties.headers, defaultTextMapGetter)
-      }
-      // create the parent span
-      parentSpan = tracer.startSpan(_rootPrefix + spanName, {
-        attributes: {
-          [ATTR_IS_MESSAGE_CREATION]: true,
-          [ATTR_SERVICE_NAME]: nodeDefinition.type,
-          ...commonAttributes,
-        },
-        kind,
-      }, ctx)
-      // create the message context
-      ctx = trace.setSpan(context.active(), parentSpan)
-      // store message parent span
-      msgSpans.set(msgId, {
-        parentSpan,
-        spans: new Map(),
-        updateTimestamp: now,
-      })
-
-      if (_isLogging) {
-        console.log('=> Created parent span for', nodeDefinition.type)
-      }
-    }
+    const spanKey = getSpanKey(msg._msgid, nodeDefinition.id)
 
     if (isNotTraced) {
-      // store fake child span (required to finish parent span)
-      msgSpans.get(msgId).spans.set(spanId, Object.assign({
-        attributes: { [ATTR_NODE_TYPE]: nodeDefinition.type },
-        _creationTimestamp: now,
-      }, fakeSpan))
+      // remembered so the node is not looked at again, but never counted as pending
+      run.ignored.add(spanKey)
       return fakeSpan
     }
-    // create child span
+
     const localAttributes = parseAttribute(false, msg, nodeDefinition.z, nodeDefinition.type)
     if (_isLogging) {
       console.log(`Local span attributes (start) for ${nodeDefinition.id}, ${nodeDefinition.type}: ${JSON.stringify(localAttributes)}`)
     }
-    const span = tracer.startSpan(spanName, {
+    const now = Date.now()
+    const span = tracer.startSpan(nodeDefinition.name || nodeDefinition.type, {
       attributes: {
         [ATTR_CODE_FUNCTION]: nodeDefinition.type,
         [ATTR_IS_MESSAGE_CREATION]: false,
-        ...commonAttributes,
+        ...getCommonAttributes(nodeDefinition, msg, run.id),
         ...localAttributes,
       },
-      kind,
-    }, ctx)
+      kind: getSpanKind(nodeDefinition.type),
+    }, run.ctx)
     span._creationTimestamp = now
 
     if (nodeDefinition.type === 'http in') {
       const httpAttributes = {
         [ATTR_URL_PATH]: nodeDefinition.url,
         [ATTR_HTTP_REQUEST_METHOD]: nodeDefinition.method.toUpperCase(),
-        [ATTR_CLIENT_ADDRESS]: msg.req.ip,
-        [ATTR_HTTP_REQUEST_HEADER('x-forwarded-for')]: msg.req.headers['x-forwarded-for'],
-        [ATTR_USER_AGENT_ORIGINAL]: msg.req.headers['user-agent'],
+        [ATTR_CLIENT_ADDRESS]: msg.req?.ip,
+        [ATTR_HTTP_REQUEST_HEADER('x-forwarded-for')]: msg.req?.headers['x-forwarded-for'],
+        [ATTR_USER_AGENT_ORIGINAL]: msg.req?.headers['user-agent'],
       }
       span.setAttributes(httpAttributes)
-      if (parentSpan !== undefined) {
-        parentSpan.setAttributes(httpAttributes)
-        parentSpan.updateName(`${parentSpan.name} ${nodeDefinition.url}`)
+      if (getSpanAttribute(run.rootSpan, ATTR_NODE_ID) === nodeDefinition.id) {
+        run.rootSpan.setAttributes(httpAttributes)
+        run.rootSpan.updateName(`${run.rootSpan.name} ${nodeDefinition.url}`)
       }
     }
     if (nodeDefinition.type === 'websocket out') {
       // add URL info in attributes
       try {
-        const url = URL.parse(nodeDefinition.serverConfig.path)
+        const url = new URL(nodeDefinition.serverConfig.path)
         span.setAttribute(ATTR_URL_PATH, url.pathname)
         span.setAttribute(ATTR_SERVER_ADDRESS, url.hostname)
         span.setAttribute(ATTR_SERVER_PORT, url.port)
         span.setAttribute(ATTR_URL_SCHEME, url.protocol.replace(':', ''))
       } catch (_error) { }
     }
-
     if (nodeDefinition.type === 'websocket in') {
       // add URL info in attributes
       span.setAttribute(ATTR_URL_PATH, nodeDefinition.serverConfig.path)
-      if (parentSpan !== undefined) {
-        parentSpan.setAttribute(ATTR_URL_PATH, nodeDefinition.serverConfig.path)
-        parentSpan.updateName(`${parentSpan.name} ${nodeDefinition.serverConfig.path}`)
+      if (getSpanAttribute(run.rootSpan, ATTR_NODE_ID) === nodeDefinition.id) {
+        run.rootSpan.setAttribute(ATTR_URL_PATH, nodeDefinition.serverConfig.path)
+        run.rootSpan.updateName(`${run.rootSpan.name} ${nodeDefinition.serverConfig.path}`)
       }
     }
 
+    run.spans.set(spanKey, span)
+    run.pending++
+    run.updateTimestamp = now
+    if (isEntry && !CORRELATED_ENTRY_TYPES.includes(nodeDefinition.type)) {
+      // this node never receives a message, so it will never report completion either:
+      // its span is closed once the message it created has been dispatched
+      run.entrySpans.add(spanKey)
+    }
     if (_isLogging) {
       console.log('=> Created span for', nodeDefinition.type)
     }
-
-    // store child span
-    const parent = msgSpans.get(msgId)
-    parent.spans.set(spanId, span)
-    parent.updateTimestamp = now
     return span
   } catch (error) {
-    console.error(`An error occurred during span creation ${eventType}`, error)
+    console.error(`An error occurred during span creation for ${nodeDefinition?.type}`, error)
   }
 }
 
@@ -350,20 +599,23 @@ function createSpan (tracer, msg, nodeDefinition, node, isNotTraced) {
  */
 function endSpan (msg, error, nodeDefinition) {
   try {
-    // check and get message id (handle root message id for splitted parts)
-    const msgId = getMsgId(msg)
-    if (!msgId) {
+    if (msg === undefined || msg === null) {
       return
     }
-    // check and get span id (msg id and node id)
-    const msgSpanId = getSpanId(msg, nodeDefinition)
-    if (!msgSpans.has(msgId) || !msgSpans.get(msgId).spans.has(msgSpanId)) {
+    const run = resolveRun([getRunId(msg), nodeStates.get(nodeDefinition.id)?.runId, msg._msgid])
+    if (run === undefined) {
       return
     }
+    const spanKey = findSpanKey(run, msg, nodeDefinition.id)
+    if (spanKey === undefined) {
+      return
+    }
+    if (run.ignored.has(spanKey)) {
+      run.ignored.delete(spanKey)
+      return
+    }
+    const span = run.spans.get(spanKey)
 
-    // end and remove child span
-    const parent = msgSpans.get(msgId)
-    const span = parent.spans.get(msgSpanId)
     if (nodeDefinition.type === 'http request') {
       // add http status code in attribute
       span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, msg.statusCode)
@@ -374,7 +626,7 @@ function endSpan (msg, error, nodeDefinition) {
       }
       // add URL info in attributes
       try {
-        const url = URL.parse(msg.responseUrl)
+        const url = new URL(msg.responseUrl)
         span.setAttribute(ATTR_URL_PATH, url.pathname)
         span.setAttribute(ATTR_SERVER_ADDRESS, url.hostname)
         span.setAttribute(ATTR_SERVER_PORT, url.port)
@@ -389,9 +641,7 @@ function endSpan (msg, error, nodeDefinition) {
         span.recordException(error)
       }
       span.setStatus({ code: SpanStatusCode.ERROR, message: error })
-      if (parent.parentSpan) {
-        parent.parentSpan.setStatus({ code: SpanStatusCode.ERROR })
-      }
+      run.rootSpan.setStatus({ code: SpanStatusCode.ERROR })
     }
     const localAttributes = parseAttribute(true, msg, nodeDefinition.z, nodeDefinition.type)
     if (localAttributes !== undefined) {
@@ -405,60 +655,34 @@ function endSpan (msg, error, nodeDefinition) {
 
     if (nodeDefinition.type === 'http response') {
       // correlate with "http in" node
-      const statusCode = msg.res._res.statusCode
-      for (const [msgSpanId, spanIn] of parent.spans) {
-        if (spanIn.attributes['node_red.node.type'] === 'http in') {
+      const statusCode = msg.res?._res?.statusCode
+      for (const [httpInSpanKey, spanIn] of run.spans) {
+        if (getSpanAttribute(spanIn, ATTR_NODE_TYPE) === 'http in') {
           if (_isLogging) {
-            console.log('==> Ended related span for ', msgSpanId, 'http in')
+            console.log('==> Ended related span for ', httpInSpanKey, 'http in')
           }
-          spanIn.end()
-          parent.spans.delete(msgSpanId)
+          endChildSpan(run, httpInSpanKey)
           break
         }
       }
       // add http status code in attribute
-      if (statusCode >= 400) {
-        span.setStatus({ code: SpanStatusCode.ERROR })
-        parent.parentSpan.setStatus({ code: SpanStatusCode.ERROR })
-      } else if (statusCode >= 200 && statusCode < 300) {
-        span.setStatus({ code: SpanStatusCode.OK })
-        parent.parentSpan.setStatus({ code: SpanStatusCode.OK })
+      if (statusCode !== undefined) {
+        if (statusCode >= 400) {
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          run.rootSpan.setStatus({ code: SpanStatusCode.ERROR })
+        } else if (statusCode >= 200 && statusCode < 300) {
+          span.setStatus({ code: SpanStatusCode.OK })
+          run.rootSpan.setStatus({ code: SpanStatusCode.OK })
+        }
+        span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, statusCode)
+        run.rootSpan.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, statusCode)
       }
-      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, statusCode)
-      parent.parentSpan.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, statusCode)
     }
 
-    span.end()
-    const currentSpanCreationTimestamp = span._creationTimestamp
     if (_isLogging) {
       console.log('==> Ended span for ', nodeDefinition.id, nodeDefinition.type)
     }
-    parent.spans.delete(msgSpanId)
-    parent.updateTimestamp = Date.now()
-
-    // check orphan traces (nodes that do not trigger complete event)
-    let isOrphan = true
-    for (const [, span] of parent.spans) {
-      if (!ORPHAN_NODE_TYPES.includes(span.attributes['node_red.node.type']) || span._creationTimestamp > currentSpanCreationTimestamp) {
-        // found an active span, skip
-        isOrphan = false
-        break
-      }
-    }
-    if (isOrphan) {
-      for (const [msgSpanId] of parent.spans) {
-        if (_isLogging) {
-          console.log(`Orphan span to delete: ${msgSpanId}`)
-        }
-        parent.spans.delete(msgSpanId)
-      }
-      // all children are completed, end and remove parent span
-      if (_isLogging) {
-        console.log(`Parent span "${parent.parentSpan.name}" no longer has child span, ending`)
-      }
-      parent.parentSpan.end()
-      msgSpans.delete(msgId)
-    }
+    endChildSpan(run, spanKey)
   } catch (error) {
     console.error(error)
   }
@@ -511,11 +735,17 @@ module.exports = function (RED) {
         return
       }
       logEvent(node, '1.onSend', events[0])
-      createSpan(tracer, events[0].msg, events[0].source.node, node, ignoredTypesList.includes(events[0].source.node.type))
+      const { msg, source } = events[0]
+      // a node emitting a message without processing one starts a run and never reports
+      // completion, so its span is flagged to be closed on dispatch
+      const isEntry = !(nodeStates.get(source.node.id)?.inFlight > 0)
+      createSpan(tracer, msg, source.node, [nodeStates.get(source.node.id)?.runId, getRunId(msg)], ignoredTypesList.includes(source.node.type), isEntry)
     })
 
     RED.hooks.add('preDeliver.otel', (sendEvent) => {
-      if (propagateHeadersTypesList.includes(sendEvent.source.node.type)) {
+      // the run is already carried by the message: `onSend` stamped it before the message was
+      // cloned for delivery, so every clone reaching this point belongs to it
+      if (propagateHeadersTypesList.includes(sendEvent.source.node.type) && sendEvent.msg.headers) {
         // remove trace context of http request headers
         propagation.fields()
           .forEach(field => {
@@ -528,72 +758,95 @@ module.exports = function (RED) {
 
     RED.hooks.add('postDeliver.otel', (sendEvent) => {
       logEvent(node, '4.postDeliver', sendEvent)
-      const span = createSpan(tracer, sendEvent.msg, sendEvent.destination.node, node, ignoredTypesList.includes(sendEvent.destination.node.type))
-      if (propagateHeadersTypesList.includes(sendEvent.destination.node.type)) {
+      const { msg, source, destination } = sendEvent
+      const span = createSpan(tracer, msg, destination.node, [getRunId(msg), nodeStates.get(source.node.id)?.runId], ignoredTypesList.includes(destination.node.type), false)
+      if (propagateHeadersTypesList.includes(destination.node.type)) {
+        const run = resolveRun([getRunId(msg)])
         const output = {}
-        const ctx = trace.setSpan(context.active(), span)
-        propagation.inject(ctx, output)
-        switch (sendEvent.destination.node.type) {
+        // the span of the receiving node when it is traced, the run itself otherwise
+        propagation.inject(span?.spanContext !== undefined ? trace.setSpan(context.active(), span) : run?.ctx ?? context.active(), output)
+        switch (destination.node.type) {
           // add trace context in mqtt v5 user properties
           case 'mqtt out':
-            if (!sendEvent.msg.userProperties) {
-              sendEvent.msg.userProperties = {}
+            if (!msg.userProperties) {
+              msg.userProperties = {}
             }
-            Object.assign(sendEvent.msg.userProperties, output)
+            Object.assign(msg.userProperties, output)
             break
           default:
             // add trace context in http request headers
-            if (!sendEvent.msg.headers) {
-              sendEvent.msg.headers = {}
+            if (!msg.headers) {
+              msg.headers = {}
             }
-            Object.assign(sendEvent.msg.headers, output)
+            Object.assign(msg.headers, output)
             break
         }
       }
-      if (sendEvent.source.node.type === 'switch' || sendEvent.source.node.type.startsWith('subflow')) {
-        // end switch or subflow spans as they do not trigger onComplete
-        const msgId = getMsgId(sendEvent.msg)
-        const spanId = getSpanId(sendEvent.msg, sendEvent.source.node)
-        const parent = msgSpans.get(msgId)
-        if (parent && parent.spans.has(spanId)) {
-          if (_isLogging) {
-            console.log(`Switch or subflow span ${spanId} will be ended`)
-          }
-          parent.spans.get(spanId).end()
-          parent.spans.delete(spanId)
+
+      const sourceRun = resolveRun([nodeStates.get(source.node.id)?.runId, getRunId(msg)])
+      if (sourceRun === undefined) {
+        return
+      }
+      const sourceSpanKey = findSpanKey(sourceRun, msg, source.node.id)
+      if (sourceSpanKey === undefined) {
+        return
+      }
+      if (sourceRun.entrySpans.has(sourceSpanKey)) {
+        // the node created this message instead of receiving one: no completion event will
+        // ever come for it, so its span ends now that the message has been dispatched
+        if (_isLogging) {
+          console.log(`Entry span ${sourceSpanKey} will be ended`)
         }
+        endChildSpan(sourceRun, sourceSpanKey)
+      } else if (source.node.type === 'switch' || source.node.type.startsWith('subflow')) {
+        // end switch or subflow spans as they do not trigger onComplete
+        if (_isLogging) {
+          console.log(`Switch or subflow span ${sourceSpanKey} will be ended`)
+        }
+        endChildSpan(sourceRun, sourceSpanKey)
       }
     })
 
     RED.hooks.add('postReceive.otel', (sendEvent) => {
       logEvent(node, '6.postReceive', sendEvent)
-      // endSpan(sendEvent.msg, null, sendEvent.destination.node)
     })
 
     RED.hooks.add('onReceive.otel', (receiveEvent) => {
-      if (receiveEvent.destination.node.type === 'split') {
-        // store parent message id before split
-        receiveEvent.msg.otelRootMsgId = getMsgId(receiveEvent.msg)
-      }
+      // remember what this node is working on, to attribute the messages it emits to this run
+      const { msg, destination } = receiveEvent
+      const state = nodeStates.get(destination.node.id) ?? { inFlight: 0 }
+      state.runId = getRunId(msg) ?? msg._msgid
+      state.msgId = msg._msgid
+      state.inFlight++
+      nodeStates.set(destination.node.id, state)
       logEvent(node, '5.onReceive', receiveEvent)
     })
 
     RED.hooks.add('onComplete.otel', (completeEvent) => {
       logEvent(node, '7.onComplete', completeEvent)
+      const state = nodeStates.get(completeEvent.node.node.id)
+      if (state !== undefined) {
+        state.inFlight = Math.max(0, state.inFlight - 1)
+      }
       endSpan(completeEvent.msg, completeEvent.error, completeEvent.node.node)
     })
 
-    // add timer for killing outdated message spans
-    intervalId = setInterval(deleteOutdatedMsgSpans, 5000)
+    // add timer for closing runs abandoned by nodes that never report completion
+    if (intervalId) {
+      clearInterval(intervalId)
+    }
+    intervalId = setInterval(sweepRuns, 5000)
 
-    // on node stop, remove previous hooks, cancel timer and clear map
+    // on node stop, remove previous hooks, cancel timer and clear maps
     this.on('close', async function () {
       if (intervalId) {
         clearInterval(intervalId)
         intervalId = null
       }
       RED.hooks.remove('*.otel')
-      msgSpans.clear()
+      runs.clear()
+      nodeStates.clear()
+      endedRuns.clear()
       await provider.shutdown()
       trace.disable()
       this.status({ fill: 'red', shape: 'ring', text: 'deactivated' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-opentelemetry",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-opentelemetry",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.6.4",
   "description": "Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for Node-RED",
   "scripts": {
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "test": "node --test \"test/**/*.test.js\""
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for Node-RED",
   "scripts": {
     "lint": "eslint . --fix",
-    "test": "node --test \"test/**/*.test.js\""
+    "test": "node --test --test-force-exit \"test/**/*.test.js\""
   },
   "engines": {
     "node": ">=18.0.0"

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -250,11 +250,17 @@ class MiniRed {
       send(received)
       done()
     })
-    handler(
-      msg,
-      (emitted) => this.send(node, emitted),
-      (error) => this.complete(node, msg, error),
-    )
+    try {
+      handler(
+        msg,
+        (emitted) => this.send(node, emitted),
+        (error) => this.complete(node, msg, error),
+      )
+    } catch (error) {
+      // a function node that throws is reported as `done(err)`, which is what puts the error on
+      // the span. `node.error()` alone would only route to a catch node (not modelled here).
+      this.complete(node, msg, error)
+    }
     this.hooks.postReceive(receiveEvent)
   }
 

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -194,6 +194,7 @@ class MiniRed {
       if (!msg._msgid) {
         msg._msgid = nextMsgId()
       }
+      // eslint-disable-next-line security/detect-object-injection
       for (const destination of ports[port] ?? []) {
         sendEvents.push({
           msg,

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -156,7 +156,8 @@ class MiniRed {
   /**
    * Wire a node to its destinations
    * @param {object} source Source node definition
-   * @param {object[]} destinations Destination node definitions
+   * @param {object[]|object[][]} destinations Destination node definitions for the single
+   *   output, or one array of destinations per output port
    */
   wire (source, destinations) {
     this.wires.set(source.id, destinations)
@@ -175,30 +176,45 @@ class MiniRed {
   /**
    * Emit a message from a node, as `node.send()` does
    * @param {object} source Source node definition
-   * @param {any} msg Message to emit (a fresh `_msgid` is minted when it has none, as
-   *   Node-RED's `Node.prototype.send` does)
+   * @param {any|any[]} msgOrArray Message to emit, or one message per output port with
+   *   `null` for the ports that emit nothing. A fresh `_msgid` is minted for any message
+   *   that has none, as Node-RED's `Node.prototype.send` does.
    */
-  send (source, msg) {
-    if (!msg._msgid) {
-      msg._msgid = nextMsgId()
-    }
-    const destinations = this.wires.get(source.id) ?? []
-    if (destinations.length === 0) {
+  send (source, msgOrArray) {
+    const perPort = Array.isArray(msgOrArray) ? msgOrArray : [msgOrArray]
+    const wires = this.wires.get(source.id) ?? []
+    const ports = Array.isArray(wires[0]) ? wires : [wires]
+
+    // Node-RED passes every message of a single `send` call to `onSend` at once
+    const sendEvents = []
+    perPort.forEach((msg, port) => {
+      if (msg === null || msg === undefined) {
+        return
+      }
+      if (!msg._msgid) {
+        msg._msgid = nextMsgId()
+      }
+      for (const destination of ports[port] ?? []) {
+        sendEvents.push({
+          msg,
+          source: { id: source.id, node: source, port },
+          destination: { id: destination.id, node: destination },
+        })
+      }
+    })
+    if (sendEvents.length === 0) {
       return
     }
-    const sendEvents = destinations.map((destination) => ({
-      msg,
-      source: { id: source.id, node: source, port: 0 },
-      destination: { id: destination.id, node: destination },
-    }))
     this.hooks.onSend(sendEvents)
-    let alreadySent = false
+
+    const dispatched = new Set()
     for (const sendEvent of sendEvents) {
-      // preRoute clones the message for every destination after the first
-      if (alreadySent) {
+      // preRoute clones a message that is being delivered more than once
+      if (dispatched.has(sendEvent.msg)) {
         sendEvent.msg = cloneMessage(sendEvent.msg)
+      } else {
+        dispatched.add(sendEvent.msg)
       }
-      alreadySent = true
       this.hooks.preDeliver(sendEvent)
       // delivery is asynchronous by default, postDeliver fires straight after preDeliver
       this.queue.push(sendEvent)

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -84,11 +84,15 @@ class MiniRed {
     this.handlers = new Map()
     this.queue = []
 
-    let registered
+    // hook labels are global to the runtime, and registering one twice throws
+    this.labelledHooks = new Set()
     const RED = {
       nodes: {
         createNode: (node) => {
-          node.status = () => {}
+          node.statuses = []
+          node.warnings = []
+          node.status = (status) => node.statuses.push(status)
+          node.warn = (warning) => node.warnings.push(warning)
           node.on = (event, callback) => {
             if (event === 'close') {
               this.closeHandler = callback.bind(node)
@@ -96,19 +100,44 @@ class MiniRed {
           }
         },
         registerType: (_type, constructor) => {
-          registered = constructor
+          this.constructNode = constructor
         },
       },
       hooks: {
         add: (name, handler) => {
-          this.hooks[name.split('.')[0]] = handler
+          const [id] = name.split('.')
+          if (this.labelledHooks.has(name)) {
+            throw new Error('Hook ' + name + ' already registered')
+          }
+          this.labelledHooks.add(name)
+          // eslint-disable-next-line security/detect-object-injection
+          this.hooks[id] = handler
         },
-        remove: () => {},
+        remove: (name) => {
+          const [id, label] = name.split('.')
+          for (const registered of [...this.labelledHooks]) {
+            const [registeredId, registeredLabel] = registered.split('.')
+            if (registeredLabel === label && (id === '*' || id === registeredId)) {
+              this.labelledHooks.delete(registered)
+            }
+          }
+        },
       },
     }
     require('../../lib/opentelemetry-node')(RED)
-    this.otelNode = {}
-    registered.call(this.otelNode, { ...DEFAULT_CONFIG, ...config })
+    this.otelNode = this.addOtelNode(config)
+  }
+
+  /**
+   * Add an OpenTelemetry node to the runtime, as placing one on a flow does
+   * @param {object} [config] Overrides of the OpenTelemetry node configuration
+   * @param {string} [id] Node identifier
+   * @returns {object} The node instance, carrying its `statuses` and `warnings`
+   */
+  addOtelNode (config = {}, id = 'otel-node-1') {
+    const node = { id }
+    this.constructNode.call(node, { ...DEFAULT_CONFIG, ...config })
+    return node
   }
 
   /**

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -1,0 +1,240 @@
+/**
+ * A minimal stand-in for the Node-RED runtime, reproducing the hook sequence of a real
+ * message delivery:
+ *
+ *   onSend -> (clone) -> preDeliver -> postDeliver -> [next tick] onReceive -> handler -> postReceive
+ *
+ * with `onComplete` triggered by the node calling `done()`. `postDeliver` firing before
+ * `onReceive`, and `onComplete` carrying the message the node *received*, both matter to the
+ * span lifecycle, so they are reproduced exactly (see Flow.js `handlePreDeliver` and
+ * Node.js `_emitInput` / `_complete` in node-red).
+ */
+
+const { ExportResultCode } = require('@opentelemetry/core')
+
+/** Spans handed to the exporter, reset by each `startRuntime` call */
+const exportedSpans = []
+
+class CollectingExporter {
+  export (spans, resultCallback) {
+    exportedSpans.push(...spans)
+    resultCallback({ code: ExportResultCode.SUCCESS })
+  }
+
+  shutdown () {
+    return Promise.resolve()
+  }
+
+  forceFlush () {
+    return Promise.resolve()
+  }
+}
+
+// The node requires its exporter lazily, so pre-seeding the module cache is enough to keep
+// spans in memory. The exported bindings are getters, so assigning on the real module object
+// would silently do nothing (and the spans would be sent to a real collector).
+for (const exporterModule of ['@opentelemetry/exporter-trace-otlp-http', '@opentelemetry/exporter-trace-otlp-proto']) {
+  const filename = require.resolve(exporterModule)
+  // eslint-disable-next-line security/detect-object-injection
+  require.cache[filename] = {
+    id: filename,
+    filename,
+    loaded: true,
+    exports: { OTLPTraceExporter: CollectingExporter },
+  }
+}
+
+const DEFAULT_CONFIG = {
+  // never reached: the exporter above is in-memory, the URL only has to be non-empty
+  url: 'http://127.0.0.1:1/v1/traces',
+  protocol: 'http',
+  serviceName: 'test',
+  rootPrefix: 'Message ',
+  ignoredTypes: 'debug,catch',
+  propagateHeadersTypes: '',
+  isLogging: false,
+  timeout: 10,
+  attributeMappings: [],
+}
+
+let messageCounter = 0
+
+function nextMsgId () {
+  return `msgid-${++messageCounter}`
+}
+
+/** Node-RED clones a message before delivering it to more than one destination */
+function cloneMessage (msg) {
+  const clone = { ...msg }
+  if (msg.headers) {
+    clone.headers = { ...msg.headers }
+  }
+  return clone
+}
+
+class MiniRed {
+  /**
+   * @param {object} [config] Overrides of the OpenTelemetry node configuration
+   */
+  constructor (config = {}) {
+    exportedSpans.length = 0
+    this.hooks = {}
+    this.nodes = new Map()
+    this.wires = new Map()
+    this.handlers = new Map()
+    this.queue = []
+
+    let registered
+    const RED = {
+      nodes: {
+        createNode: (node) => {
+          node.status = () => {}
+          node.on = (event, callback) => {
+            if (event === 'close') {
+              this.closeHandler = callback.bind(node)
+            }
+          }
+        },
+        registerType: (_type, constructor) => {
+          registered = constructor
+        },
+      },
+      hooks: {
+        add: (name, handler) => {
+          this.hooks[name.split('.')[0]] = handler
+        },
+        remove: () => {},
+      },
+    }
+    require('../../lib/opentelemetry-node')(RED)
+    this.otelNode = {}
+    registered.call(this.otelNode, { ...DEFAULT_CONFIG, ...config })
+  }
+
+  /**
+   * Declare a node
+   * @param {string} id Node identifier
+   * @param {string} type Node type
+   * @param {object} [definition] Extra definition properties (name, url, method, ...)
+   * @returns {object} The node definition
+   */
+  node (id, type, definition = {}) {
+    const node = { id, type, z: 'flow-1', name: '', _flow: { flow: { label: 'Test flow' } }, ...definition }
+    this.nodes.set(id, node)
+    return node
+  }
+
+  /**
+   * Wire a node to its destinations
+   * @param {object} source Source node definition
+   * @param {object[]} destinations Destination node definitions
+   */
+  wire (source, destinations) {
+    this.wires.set(source.id, destinations)
+  }
+
+  /**
+   * Register what a node does when it receives a message. The default forwards the message
+   * unchanged and reports completion, like most core nodes.
+   * @param {object} node Node definition
+   * @param {(msg: any, send: (msg: any) => void, done: (error?: any) => void) => void} handler
+   */
+  on (node, handler) {
+    this.handlers.set(node.id, handler)
+  }
+
+  /**
+   * Emit a message from a node, as `node.send()` does
+   * @param {object} source Source node definition
+   * @param {any} msg Message to emit (a fresh `_msgid` is minted when it has none, as
+   *   Node-RED's `Node.prototype.send` does)
+   */
+  send (source, msg) {
+    if (!msg._msgid) {
+      msg._msgid = nextMsgId()
+    }
+    const destinations = this.wires.get(source.id) ?? []
+    if (destinations.length === 0) {
+      return
+    }
+    const sendEvents = destinations.map((destination) => ({
+      msg,
+      source: { id: source.id, node: source, port: 0 },
+      destination: { id: destination.id, node: destination },
+    }))
+    this.hooks.onSend(sendEvents)
+    let alreadySent = false
+    for (const sendEvent of sendEvents) {
+      // preRoute clones the message for every destination after the first
+      if (alreadySent) {
+        sendEvent.msg = cloneMessage(sendEvent.msg)
+      }
+      alreadySent = true
+      this.hooks.preDeliver(sendEvent)
+      // delivery is asynchronous by default, postDeliver fires straight after preDeliver
+      this.queue.push(sendEvent)
+      this.hooks.postDeliver(sendEvent)
+    }
+  }
+
+  /** Deliver every queued message, running the receiving nodes until the flow settles */
+  run () {
+    let guard = 0
+    while (this.queue.length > 0) {
+      if (++guard > 10000) {
+        throw new Error('flow did not settle')
+      }
+      const sendEvent = this.queue.shift()
+      this.deliver(sendEvent.destination.node, sendEvent.msg)
+    }
+  }
+
+  /**
+   * Hand a message to a node, as `Node.prototype.receive` does
+   * @param {object} node Node definition
+   * @param {any} msg Message data
+   */
+  deliver (node, msg) {
+    if (!msg._msgid) {
+      msg._msgid = nextMsgId()
+    }
+    const receiveEvent = { msg, destination: { id: node.id, node } }
+    this.hooks.onReceive(receiveEvent)
+    const handler = this.handlers.get(node.id) ?? ((received, send, done) => {
+      send(received)
+      done()
+    })
+    handler(
+      msg,
+      (emitted) => this.send(node, emitted),
+      (error) => this.complete(node, msg, error),
+    )
+    this.hooks.postReceive(receiveEvent)
+  }
+
+  /**
+   * Report completion for a message, as `Node.prototype._complete` does
+   * @param {object} node Node definition
+   * @param {any} msg The message the node received
+   * @param {any} [error] Error encountered
+   */
+  complete (node, msg, error) {
+    this.hooks.onComplete({ msg, error, node: { id: node.id, node } })
+  }
+
+  /**
+   * Shut the node down, which flushes the span processor, and return the exported spans
+   * @returns {Promise<import('@opentelemetry/sdk-trace-base').ReadableSpan[]>}
+   */
+  async stop () {
+    await this.closeHandler()
+    return exportedSpans.slice()
+  }
+}
+
+/** @param {number} ms */
+function sleep (ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+module.exports = { MiniRed, sleep, nextMsgId }

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -224,3 +224,25 @@ test('a run abandoned by a node still exports its open spans', async () => {
   assert.equal(root.attributes['node_red.span.incomplete'], true)
   assert.equal(traceIdsOf(spans).size, 1)
 })
+
+test('a second OpenTelemetry node stays inactive instead of failing the deploy', async () => {
+  const red = new MiniRed()
+  // adding the node to another flow used to throw "Hook onSend.otel already registered",
+  // which fails the deploy of that flow
+  const second = red.addOtelNode({ rootPrefix: 'Clobbered ' }, 'otel-node-2')
+
+  assert.deepEqual(second.statuses.at(-1), { fill: 'grey', shape: 'ring', text: 'inactive, another OTEL node is active' })
+  assert.match(second.warnings.at(-1), /already handled by node "otel-node-1"/)
+
+  // the node that owns the hooks keeps tracing, with its own settings
+  const inject = red.node('n1', 'inject')
+  const change = red.node('n2', 'change')
+  red.wire(inject, [change])
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  assert.equal(byName(spans, 'change').length, 1)
+  assert.equal(rootOf(spans).name, 'Message inject', 'the inactive node must not override the active settings')
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -539,3 +539,39 @@ test('the documented attribute mappings carry per attempt values through a retry
   // but never the run span: mappings only land on the node spans below it
   assert.equal(rootOf(spans).attributes['node_red.session.id'], undefined)
 })
+
+test('the run span records what triggered the run', async () => {
+  const red = new MiniRed()
+  const httpIn = red.node('n1', 'http in', { url: '/trigger', method: 'get' })
+  const fn = red.node('n2', 'function', { name: 'work' })
+  const httpResponse = red.node('n3', 'http response')
+  red.wire(httpIn, [fn])
+  red.wire(fn, [httpResponse])
+  red.on(httpResponse, (msg, send, done) => done())
+
+  red.send(httpIn, { payload: '', req: { ip: '127.0.0.1', headers: {} }, res: { _res: { statusCode: 200 } } })
+  red.run()
+  const spans = await red.stop()
+
+  const root = rootOf(spans)
+  assert.equal(root.attributes['node_red.trigger.type'], 'http in')
+  // only the run span carries it: on a node span the type is already node_red.node.type, and
+  // "what triggered the run" would be wrong there
+  for (const span of spans.filter((span) => span !== root)) {
+    assert.equal(span.attributes['node_red.trigger.type'], undefined, `${span.name} must not claim to be the trigger`)
+  }
+  assert.equal(byName(spans, 'work')[0].attributes['node_red.node.type'], 'function')
+})
+
+test('an inject started run is labelled by its own trigger type', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const change = red.node('n2', 'change')
+  red.wire(inject, [change])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(rootOf(spans).attributes['node_red.trigger.type'], 'inject')
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -1,0 +1,226 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const { MiniRed, sleep } = require('./helpers/mini-red')
+
+/** ReadableSpan exposes the parent as `parentSpanId` (SDK 1.x) or `parentSpanContext` (2.x) */
+function parentSpanIdOf (span) {
+  return span.parentSpanId ?? span.parentSpanContext?.spanId
+}
+
+function traceIdsOf (spans) {
+  return new Set(spans.map((span) => span.spanContext().traceId))
+}
+
+function byName (spans, name) {
+  return spans.filter((span) => span.name === name)
+}
+
+/**
+ * The span standing for the whole flow execution. It is identified by `node_red.msg.new`
+ * rather than by the absence of a parent, since it is a child of the caller span whenever the
+ * entry node received a trace context from outside Node-RED.
+ */
+function runSpansOf (spans) {
+  return spans.filter((span) => span.attributes['node_red.msg.new'] === true)
+}
+
+function rootOf (spans) {
+  const roots = runSpansOf(spans)
+  assert.equal(roots.length, 1, `expected exactly one run span, got ${roots.map((s) => s.name).join(', ')}`)
+  return roots[0]
+}
+
+test('a message forwarded unchanged produces a single trace', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const change = red.node('n2', 'change')
+  const debug = red.node('n3', 'debug')
+  red.wire(inject, [change])
+  red.wire(change, [debug])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  const root = rootOf(spans)
+  assert.equal(root.name, 'Message inject')
+  assert.equal(parentSpanIdOf(root), undefined, 'with no incoming context the run span is a trace root')
+  // debug is in the ignored types, so it gets no span
+  assert.deepEqual(spans.map((span) => span.name).sort(), ['Message inject', 'change', 'inject'])
+  for (const span of spans.filter((span) => span !== root)) {
+    assert.equal(parentSpanIdOf(span), root.spanContext().spanId)
+    assert.equal(span.attributes['node_red.run.id'], root.attributes['node_red.run.id'])
+  }
+})
+
+test('a node emitting a brand new message stays in the same trace', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const fn = red.node('n2', 'function')
+  const change = red.node('n3', 'change')
+  const debug = red.node('n4', 'debug')
+  red.wire(inject, [fn])
+  red.wire(fn, [change])
+  red.wire(change, [debug])
+  // returning a new object instead of the received message: Node-RED mints a fresh _msgid,
+  // which used to start a second, unrelated trace
+  red.on(fn, (msg, send, done) => {
+    send({ payload: 'rebuilt' })
+    done()
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1, 'the whole execution must be one trace')
+  const root = rootOf(spans)
+  assert.equal(byName(spans, 'function').length, 1, 'the function node must get exactly one span')
+  const changeSpan = byName(spans, 'change')[0]
+  assert.equal(parentSpanIdOf(changeSpan), root.spanContext().spanId)
+  // the downstream span carries its own message id, and the run id of the whole execution
+  assert.notEqual(changeSpan.attributes['node_red.msg.id'], root.attributes['node_red.msg.id'])
+  assert.equal(changeSpan.attributes['node_red.run.id'], root.attributes['node_red.run.id'])
+})
+
+test('split parts stay in the trace of the message they came from', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const split = red.node('n2', 'split')
+  const change = red.node('n3', 'change')
+  const debug = red.node('n4', 'debug')
+  red.wire(inject, [split])
+  red.wire(split, [change])
+  red.wire(change, [debug])
+  red.on(split, (msg, send, done) => {
+    for (const part of ['a', 'b', 'c']) {
+      send({ payload: part })
+    }
+    done()
+  })
+
+  red.send(inject, { payload: ['a', 'b', 'c'] })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  assert.equal(byName(spans, 'split').length, 1, 'the split node must get one span, not one per part')
+  assert.equal(byName(spans, 'change').length, 3, 'each part must get its own downstream span')
+  const root = rootOf(spans)
+  for (const span of byName(spans, 'change')) {
+    assert.equal(parentSpanIdOf(span), root.spanContext().spanId)
+  }
+})
+
+test('an incoming trace context is continued instead of starting a new trace', async () => {
+  const red = new MiniRed()
+  const callerTraceId = '0af7651916cd43dd8448eb211c80319c'
+  const callerSpanId = 'b7ad6b7169203331'
+  const httpIn = red.node('n1', 'http in', { url: '/test', method: 'get' })
+  const fn = red.node('n2', 'function')
+  const httpResponse = red.node('n3', 'http response')
+  red.wire(httpIn, [fn])
+  red.wire(fn, [httpResponse])
+  red.on(httpResponse, (msg, send, done) => done())
+
+  red.send(httpIn, {
+    payload: '',
+    req: { ip: '127.0.0.1', headers: { traceparent: `00-${callerTraceId}-${callerSpanId}-01`, 'user-agent': 'test' } },
+    res: { _res: { statusCode: 200 } },
+  })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  const root = rootOf(spans)
+  assert.equal(root.spanContext().traceId, callerTraceId, 'the run must join the caller trace')
+  assert.equal(parentSpanIdOf(root), callerSpanId, 'the run must be a child of the caller span')
+  assert.equal(root.name, 'Message http in /test')
+  assert.equal(root.attributes['http.response.status_code'], 200)
+  // the "http in" span is closed by the "http response" node, and must be exported
+  assert.equal(byName(spans, 'http in').length, 1)
+  assert.equal(byName(spans, 'http response').length, 1)
+})
+
+test('a node that emits without receiving gets its span exported', async () => {
+  const red = new MiniRed()
+  // tcp in never receives a message and never reports completion (issue #15)
+  const tcpIn = red.node('n1', 'tcp in')
+  const debug = red.node('n2', 'debug')
+  red.wire(tcpIn, [debug])
+
+  red.send(tcpIn, { payload: 'from the socket' })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(byName(spans, 'tcp in').length, 1, 'the entry span must not be dropped')
+  const root = rootOf(spans)
+  assert.equal(root.name, 'Message tcp in')
+  assert.equal(traceIdsOf(spans).size, 1)
+})
+
+test('an error marks both the node span and the run as failed', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const fn = red.node('n2', 'function')
+  red.wire(inject, [fn])
+  red.on(fn, (msg, send, done) => done('boom'))
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  const fnSpan = byName(spans, 'function')[0]
+  assert.equal(fnSpan.status.code, 2, 'node span must be ERROR')
+  assert.equal(rootOf(spans).status.code, 2, 'run span must be ERROR')
+})
+
+test('a message emitted after the run finished starts a linked trace', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  // a node that acknowledges the message and emits later, decoupling input from output
+  const delay = red.node('n2', 'delay')
+  const change = red.node('n3', 'change')
+  red.wire(inject, [delay])
+  red.wire(delay, [change])
+  red.on(delay, (msg, send, done) => done())
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  // the queued message is released once the first run is already over
+  red.send(delay, { payload: 'released' })
+  red.run()
+  const spans = await red.stop()
+
+  const traceIds = traceIdsOf(spans)
+  assert.equal(traceIds.size, 2, 'an asynchronous hand-off is a separate trace')
+  const roots = runSpansOf(spans)
+  assert.equal(roots.length, 2)
+  const [firstRoot, secondRoot] = roots
+  assert.equal(secondRoot.links.length, 1, 'the continuation must be linked to the run it came from')
+  assert.equal(secondRoot.links[0].context.spanId, firstRoot.spanContext().spanId)
+  assert.equal(secondRoot.links[0].attributes['node_red.link.type'], 'continuation')
+})
+
+test('a run abandoned by a node still exports its open spans', async () => {
+  // timeout is deliberately short; the sweep runs every 5s
+  const red = new MiniRed({ timeout: 0.05 })
+  const inject = red.node('n1', 'inject')
+  const stuck = red.node('n2', 'function', { name: 'never completes' })
+  red.wire(inject, [stuck])
+  red.on(stuck, () => { /* neither sends nor reports completion */ })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  await sleep(5300)
+  const spans = await red.stop()
+
+  const stuckSpan = byName(spans, 'never completes')[0]
+  assert.ok(stuckSpan, 'the unfinished span must be exported instead of dropped')
+  assert.equal(stuckSpan.attributes['node_red.span.incomplete'], true)
+  const root = rootOf(spans)
+  assert.equal(root.attributes['node_red.span.incomplete'], true)
+  assert.equal(traceIdsOf(spans).size, 1)
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -457,7 +457,10 @@ test('the documented attribute mappings carry per attempt values through a retry
   // exactly the rows the example flow documents
   const red = new MiniRed({
     attributeMappings: [
-      { isAfter: false, flow: '', nodeType: 'function', key: 'node_red.file.name', path: 'payload.filename' },
+      // a plain top level property, which the example flow lifts the filename onto before the
+      // loop, and the same value read out of the payload the worker rewrites each iteration
+      { isAfter: false, flow: '', nodeType: '', key: 'node_red.file.name', path: 'filename' },
+      { isAfter: false, flow: '', nodeType: 'function', key: 'node_red.file.from.payload', path: 'payload.filename' },
       { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.attempt', path: 'attempts' },
       { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.outcome', path: 'outcome' },
       { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.error.reason', path: 'lastError' },
@@ -478,7 +481,7 @@ test('the documented attribute mappings carry per attempt values through a retry
   red.wire(outcome, [[work], [done]])
 
   red.on(split, (msg, send, cb) => {
-    send({ sessionId: 'S-test', payload: { filename: 'orders-2026-07-30.csv' } })
+    send({ sessionId: 'S-test', filename: 'orders-2026-07-30.csv', payload: { filename: 'orders-2026-07-30.csv' } })
     cb()
   })
   // as the flow's worker does: fail twice, then succeed on the third attempt
@@ -510,9 +513,14 @@ test('the documented attribute mappings carry per attempt values through a retry
 
   const attempts = byName(spans, 'process attempt')
   assert.equal(attempts.length, 3)
-  // the filename survives every iteration, because the worker keeps it in the payload
+  // a top level property survives every iteration whatever the worker does to the payload
   assert.deepEqual(attempts.map((s) => s.attributes['node_red.file.name']),
     ['orders-2026-07-30.csv', 'orders-2026-07-30.csv', 'orders-2026-07-30.csv'])
+  // reading out of the payload works too, but only while the worker keeps putting it back
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.file.from.payload']),
+    ['orders-2026-07-30.csv', 'orders-2026-07-30.csv', 'orders-2026-07-30.csv'])
+  // a mapping with no node type also reaches the switch spans, which End would miss
+  assert.equal(byName(spans, 'outcome?')[0].attributes['node_red.file.name'], 'orders-2026-07-30.csv')
   assert.deepEqual(attempts.map((s) => s.attributes['node_red.attempt']), [1, 2, 3])
   assert.deepEqual(attempts.map((s) => s.attributes['node_red.outcome']), ['retry', 'retry', 'ok'])
   // the reason is only there for the attempts that failed

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -246,3 +246,70 @@ test('a second OpenTelemetry node stays inactive instead of failing the deploy',
   assert.equal(byName(spans, 'change').length, 1)
   assert.equal(rootOf(spans).name, 'Message inject', 'the inactive node must not override the active settings')
 })
+
+test('a session looping over two messages is one trace with a span per iteration', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject', { name: 'start session' })
+  const start = red.node('n2', 'function', { name: 'start session' })
+  const split = red.node('n3', 'split', { name: '2 messages' })
+  const work = red.node('n4', 'function', { name: 'process attempt' })
+  const more = red.node('n5', 'switch', { name: 'more attempts?' })
+  const join = red.node('n6', 'join', { name: 'session results' })
+  const debug = red.node('n7', 'debug', { name: 'session done' })
+  red.wire(inject, [start])
+  red.wire(start, [split])
+  red.wire(split, [work])
+  red.wire(work, [more])
+  // two output ports: back to the worker, or on to the join
+  red.wire(more, [[work], [join]])
+  red.wire(join, [debug])
+
+  // a brand new object, so Node-RED mints a fresh _msgid for the session
+  red.on(start, (msg, send, done) => {
+    send({ sessionId: 'S-test', payload: [{ item: 'alpha' }, { item: 'beta' }] })
+    done()
+  })
+  red.on(split, (msg, send, done) => {
+    for (const item of msg.payload) {
+      send({ sessionId: msg.sessionId, payload: item })
+    }
+    done()
+  })
+  red.on(work, (msg, send, done) => {
+    const item = msg.payload.item
+    msg.attempts = (msg.attempts || 0) + 1
+    msg.payload = { session: msg.sessionId, item, attempt: msg.attempts }
+    send(msg)
+    done()
+  })
+  red.on(more, (msg, send, done) => {
+    // attempts < 3 loops back on port 0, otherwise leaves on port 1
+    send(msg.attempts < 3 ? [msg, null] : [null, msg])
+    done()
+  })
+  const collected = []
+  red.on(join, (msg, send, done) => {
+    collected.push(msg)
+    if (collected.length === 2) {
+      send({ sessionId: msg.payload.session, payload: collected.map((m) => m.payload) })
+    }
+    done()
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1, 'the whole session must be one trace')
+  const root = rootOf(spans)
+  assert.equal(byName(spans, 'process attempt').length, 6, '2 messages x 3 attempts, one span each')
+  assert.equal(byName(spans, 'more attempts?').length, 6, 'the switch node is entered once per iteration')
+  assert.equal(byName(spans, '2 messages').length, 1)
+  assert.equal(byName(spans, 'session results').length, 2, 'one span per message reaching the join')
+  for (const span of spans.filter((span) => span !== root)) {
+    assert.equal(parentSpanIdOf(span), root.spanContext().spanId)
+    assert.equal(span.attributes['node_red.run.id'], root.attributes['node_red.run.id'])
+  }
+  // nothing may be left flagged as unfinished
+  assert.equal(spans.filter((span) => span.attributes['node_red.span.incomplete']).length, 0)
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -313,3 +313,93 @@ test('a session looping over two messages is one trace with a span per iteration
   // nothing may be left flagged as unfinished
   assert.equal(spans.filter((span) => span.attributes['node_red.span.incomplete']).length, 0)
 })
+
+test('a thrown error keeps its message on the span and marks the run', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const work = red.node('n2', 'function', { name: 'process attempt' })
+  red.wire(inject, [work])
+  red.on(work, () => {
+    throw new Error('still failing after 3 attempts')
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  const workSpan = byName(spans, 'process attempt')[0]
+  assert.equal(workSpan.status.code, 2)
+  // the SDK drops a status message that is not a string, so an Error must be unwrapped
+  assert.equal(workSpan.status.message, 'still failing after 3 attempts')
+  assert.equal(workSpan.events.at(-1)?.name, 'exception')
+  assert.equal(rootOf(spans).status.code, 2, 'the run must be marked failed')
+})
+
+test('a session where one message is retried and another gives up is still one trace', async () => {
+  const red = new MiniRed()
+  const inject = red.node('n1', 'inject')
+  const start = red.node('n2', 'function', { name: 'build session' })
+  const split = red.node('n3', 'split', { name: 'fan out items' })
+  const work = red.node('n4', 'function', { name: 'process attempt' })
+  const outcome = red.node('n5', 'switch', { name: 'outcome?' })
+  const done = red.node('n6', 'debug', { name: 'item done' })
+  red.wire(inject, [start])
+  red.wire(start, [split])
+  red.wire(split, [work])
+  red.wire(work, [outcome])
+  red.wire(outcome, [[work], [done]])
+
+  red.on(start, (msg, send, cb) => {
+    send({ sessionId: 'S-test', payload: [{ item: 'alpha' }, { item: 'beta' }] })
+    cb()
+  })
+  red.on(split, (msg, send, cb) => {
+    for (const item of msg.payload) {
+      send({ sessionId: msg.sessionId, payload: item })
+    }
+    cb()
+  })
+  // scripted instead of random: alpha fails once then succeeds, beta never succeeds
+  const MAX_ATTEMPTS = 3
+  red.on(work, (msg, send, cb) => {
+    const item = msg.payload.item
+    msg.attempts = (msg.attempts || 0) + 1
+    const succeeds = item === 'alpha' && msg.attempts === 2
+    if (succeeds) {
+      msg.outcome = 'ok'
+      msg.payload = { item, attempt: msg.attempts }
+      send(msg)
+      return cb()
+    }
+    if (msg.attempts >= MAX_ATTEMPTS) {
+      throw new Error(`${item} still failing after ${msg.attempts} attempts`)
+    }
+    msg.outcome = 'retry'
+    msg.payload = { item, attempt: msg.attempts }
+    send(msg)
+    cb()
+  })
+  red.on(outcome, (msg, send, cb) => {
+    send(msg.outcome === 'retry' ? [msg, null] : [null, msg])
+    cb()
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1, 'a partly failed session is still one trace')
+  const root = rootOf(spans)
+  // alpha: 2 attempts then ok. beta: 3 attempts, the last one throws
+  assert.equal(byName(spans, 'process attempt').length, 5)
+  const failed = byName(spans, 'process attempt').filter((span) => span.status.code === 2)
+  assert.equal(failed.length, 1, 'only the attempt that gave up is an error')
+  assert.match(failed[0].status.message, /beta still failing after 3 attempts/)
+  assert.equal(root.status.code, 2, 'one failed message fails the run')
+  // the successful message must not be left hanging by the failure of the other
+  assert.equal(spans.filter((span) => span.attributes['node_red.span.incomplete']).length, 0)
+  for (const span of spans.filter((span) => span !== root)) {
+    assert.equal(parentSpanIdOf(span), root.spanContext().spanId)
+  }
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -403,3 +403,131 @@ test('a session where one message is retried and another gives up is still one t
     assert.equal(parentSpanIdOf(span), root.spanContext().spanId)
   }
 })
+
+test('custom attributes are evaluated per loop iteration', async () => {
+  const red = new MiniRed({
+    attributeMappings: [
+      // the file being worked on is set before the loop, so it is there at span start
+      { isAfter: false, flow: '', nodeType: 'function', key: 'node_red.file.name', path: 'filename' },
+      // the attempt number is set by the node itself, so only the end of the span sees it
+      { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.attempt', path: 'attempts' },
+      // the same value read at span start instead, to pin down what that gives
+      { isAfter: false, flow: '', nodeType: 'function', key: 'node_red.attempt.at.start', path: 'attempts' },
+    ],
+  })
+  const inject = red.node('n1', 'inject')
+  const work = red.node('n2', 'function', { name: 'process attempt' })
+  const outcome = red.node('n3', 'switch', { name: 'outcome?' })
+  const done = red.node('n4', 'debug')
+  red.wire(inject, [work])
+  red.wire(work, [outcome])
+  red.wire(outcome, [[work], [done]])
+
+  red.on(work, (msg, send, cb) => {
+    msg.attempts = (msg.attempts || 0) + 1
+    msg.outcome = msg.attempts < 3 ? 'retry' : 'ok'
+    send(msg)
+    cb()
+  })
+  red.on(outcome, (msg, send, cb) => {
+    send(msg.outcome === 'retry' ? [msg, null] : [null, msg])
+    cb()
+  })
+
+  // the filename arrives with the message, as a split node would hand it over
+  red.send(inject, { payload: 1, filename: 'orders-2026-07-30.csv' })
+  red.run()
+  const spans = await red.stop()
+
+  const attempts = byName(spans, 'process attempt')
+  assert.equal(attempts.length, 3, 'one span per iteration')
+
+  // an attribute set before the loop is on every iteration
+  for (const span of attempts) {
+    assert.equal(span.attributes['node_red.file.name'], 'orders-2026-07-30.csv')
+  }
+  // read at the end of the span, the attempt number is that of the iteration
+  assert.deepEqual(attempts.map((span) => span.attributes['node_red.attempt']), [1, 2, 3])
+  // read at the start it is whatever the previous iteration left behind, hence off by one:
+  // the first has no value at all, since the node had not counted anything yet
+  assert.deepEqual(attempts.map((span) => span.attributes['node_red.attempt.at.start']), [undefined, 1, 2])
+})
+
+test('the documented attribute mappings carry per attempt values through a retry loop', async () => {
+  // exactly the rows the example flow documents
+  const red = new MiniRed({
+    attributeMappings: [
+      { isAfter: false, flow: '', nodeType: 'function', key: 'node_red.file.name', path: 'payload.filename' },
+      { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.attempt', path: 'attempts' },
+      { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.outcome', path: 'outcome' },
+      { isAfter: true, flow: '', nodeType: 'function', key: 'node_red.error.reason', path: 'lastError' },
+      // Start, not End: a switch span is closed on dispatch rather than on completion, so End
+      // mappings never reach it
+      { isAfter: false, flow: '', nodeType: '', key: 'node_red.session.id', path: 'sessionId' },
+      { isAfter: true, flow: '', nodeType: '', key: 'node_red.session.at.end', path: 'sessionId' },
+    ],
+  })
+  const inject = red.node('n1', 'inject')
+  const split = red.node('n2', 'split', { name: 'fan out items' })
+  const work = red.node('n3', 'function', { name: 'process attempt' })
+  const outcome = red.node('n4', 'switch', { name: 'outcome?' })
+  const done = red.node('n5', 'debug')
+  red.wire(inject, [split])
+  red.wire(split, [work])
+  red.wire(work, [outcome])
+  red.wire(outcome, [[work], [done]])
+
+  red.on(split, (msg, send, cb) => {
+    send({ sessionId: 'S-test', payload: { filename: 'orders-2026-07-30.csv' } })
+    cb()
+  })
+  // as the flow's worker does: fail twice, then succeed on the third attempt
+  red.on(work, (msg, send, cb) => {
+    const source = msg.payload
+    const filename = source.filename
+    msg.attempts = (msg.attempts || 0) + 1
+    const progress = { session: msg.sessionId, filename, attempt: msg.attempts }
+    if (msg.attempts >= 3) {
+      msg.outcome = 'ok'
+      delete msg.lastError
+      msg.payload = { ...progress, outcome: 'ok' }
+    } else {
+      msg.outcome = 'retry'
+      msg.lastError = `${filename} failed on attempt ${msg.attempts}`
+      msg.payload = { ...progress, outcome: 'retry' }
+    }
+    send(msg)
+    cb()
+  })
+  red.on(outcome, (msg, send, cb) => {
+    send(msg.outcome === 'retry' ? [msg, null] : [null, msg])
+    cb()
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  const attempts = byName(spans, 'process attempt')
+  assert.equal(attempts.length, 3)
+  // the filename survives every iteration, because the worker keeps it in the payload
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.file.name']),
+    ['orders-2026-07-30.csv', 'orders-2026-07-30.csv', 'orders-2026-07-30.csv'])
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.attempt']), [1, 2, 3])
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.outcome']), ['retry', 'retry', 'ok'])
+  // the reason is only there for the attempts that failed
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.error.reason']), [
+    'orders-2026-07-30.csv failed on attempt 1',
+    'orders-2026-07-30.csv failed on attempt 2',
+    undefined,
+  ])
+  // a mapping without a node type reaches every traced node
+  assert.deepEqual(attempts.map((s) => s.attributes['node_red.session.id']), ['S-test', 'S-test', 'S-test'])
+  assert.equal(byName(spans, 'outcome?')[0].attributes['node_red.session.id'], 'S-test')
+  // the switch span is closed when the message is dispatched rather than on completion, so an
+  // End mapping does not reach it, while it does reach a node that reports completion
+  assert.equal(byName(spans, 'outcome?')[0].attributes['node_red.session.at.end'], undefined)
+  assert.equal(attempts[0].attributes['node_red.session.at.end'], 'S-test')
+  // but never the run span: mappings only land on the node spans below it
+  assert.equal(rootOf(spans).attributes['node_red.session.id'], undefined)
+})


### PR DESCRIPTION
## Problem

A trace is currently scoped to a Node-RED **message id**, so one execution of a flow is split across several unrelated traces, and some spans never reach the collector at all.

Four separate mechanisms cause it:

1. **A new `_msgid` mid-flow starts a new trace.** `Node.prototype.send` mints a fresh `_msgid` for every message object a node emits that does not already have one. So a `function` node returning `{payload: ...}` instead of the message it received — and likewise `join`, `batch`, or any node calling `node.send({...})` — creates a root span with no relationship to what came before. `split` was the only case handled, through `otelRootMsgId`.

2. **The parent span was ended too eagerly.** `endSpan` ended the parent and deleted the map entry as soon as the child span map was momentarily empty. That only holds while delivery is synchronous and same-tick (the next node's span is created at `postDeliver` before the previous node's `onComplete`). Anything asynchronous — `delay`, `trigger`, a waiting `join`, or a fan-out where one branch finishes before a sibling starts — left the run to be re-rooted into another trace, repeatedly.

3. **The timeout dropped spans.** When a run went idle past `timeout` (default 10s), the parent span was ended but the child spans still open were deleted from the map *without being ended*, so the SDK never exported them. Any single node slower than the timeout also guaranteed the run would split.

4. **`otelRootMsgId` was never cleared.** A message stored and sent again later still pointed at a root span that had already ended, and the re-minted root reused the same `node_red.msg.id`, so grouping by that attribute could not recover the run either.

## What this changes

The **run** becomes the unit of a trace. The first node to emit opens a run span; the run id is carried on the message so every node downstream joins it whatever the message id becomes; and the run span ends when its last node span ends — reference counted, instead of inferred from an empty map.

Beyond the four causes above:

- **Continue the caller trace.** Context extraction (`http in` headers, `mqtt in` v5 user properties, `amqp-in` headers) previously only ran if the root span happened to be created at that node. It now always runs for the node that starts the run, so a Node-RED execution is a subtree of the caller's trace when a `traceparent` arrives, rather than a new trace.
- **Nodes that never report completion** (`tcp in`, `server-events`, ...) get their span closed once the message they created has been dispatched, so they stop being missing from traces — this is #15. `http in` keeps its existing correlation with `http response`.
- **Abandoned runs no longer lose spans.** The sweep ends the node spans still open, flags them `node_red.span.incomplete`, and ends the run span at its last activity timestamp, so durations stay accurate.
- **Asynchronous hand-offs are linked, not merged.** When a node acknowledges a message and emits it later (`delay`, `trigger`, a rate limiter), the continuation is a new run carrying a span link back to the run it came from (`node_red.link.type: continuation`). That follows the [messaging semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/), which use links as the default producer/consumer correlation, and it also keeps traces bounded.

### Smaller fixes found along the way

- `createSpan`'s `catch` referenced an undefined `eventType`, so it raised a `ReferenceError` that masked the original error and propagated out of the hook.
- The root span set `service.name` to the *node type*. `service.name` identifies the service and belongs to the Resource, where it is already set correctly; a span-level override confuses any backend that keys service identity from it. Removed — the node type is already on `node_red.node.type`.
- `URL.parse` is a static method added in Node 22, but the package supports `>=18`. On Node 18/20 it threw into a silent `catch`, so the http and websocket url attributes were quietly missing. Replaced with `new URL`.
- Guarded `msg.req`, `msg.res._res` and `msg.headers` accesses, which could throw depending on the node emitting the message.

### Attributes

- added `node_red.run.id` — the flow execution,
- `node_red.msg.id` now holds the id of the message the node actually processed. It was the run id before, which was the same value except for `split` parts,
- added `node_red.span.incomplete` and `node_red.link.type`.

## Behaviour worth flagging

`otelRootMsgId` is now set on every message rather than only after a `split`, so it becomes visible in the debug sidebar. It has to be an ordinary enumerable property: `RED.util.cloneMessage` would not carry a non-enumerable one across the clone that happens on delivery.

Ending the run span as soon as its last node span ends means an asynchronous hand-off produces a linked pair of traces instead of one. A settle delay before closing the run would merge more of those into a single trace at the cost of holding runs open longer — happy to add it behind a config field if you would prefer that trade-off.

## Tests

Adds a suite (`npm test`, `node:test`, no new dependencies) that drives the real hook sequence — `onSend → preRoute (clone) → preDeliver → postDeliver → onReceive → handler → postReceive`, with `onComplete` carrying the message the node *received* — against an in-memory exporter. `postDeliver` firing before `onReceive` is what makes the reference count safe, so the harness reproduces it exactly.

Covered: a pass-through flow, a node emitting a brand new message object, `split` fan-out, incoming trace context continuation, an entry node that never completes, error propagation to the run span, the linked asynchronous hand-off, and an abandoned run.

```
✔ a message forwarded unchanged produces a single trace
✔ a node emitting a brand new message stays in the same trace
✔ split parts stay in the trace of the message they came from
✔ an incoming trace context is continued instead of starting a new trace
✔ a node that emits without receiving gets its span exported
✔ an error marks both the node span and the run as failed
✔ a message emitted after the run finished starts a linked trace
✔ a run abandoned by a node still exports its open spans
```

`npm run lint` is clean. `test/` is excluded from the published package via `.npmignore`.
