### PR TITLE
feat(trace): add exporter authentication

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .eslintrc.json
 .github
 docs
+test
 node-red-contrib-opentelemetry-*.tgz

--- a/README.md
+++ b/README.md
@@ -78,12 +78,36 @@ As with every [node installation](https://nodered.org/docs/user-guide/runtime/ad
 - Setup the node:
   - set OTEL [exporter](https://opentelemetry.io/docs/instrumentation/js/exporters/) url (example for Jaeger: `http://localhost:4318/v1/traces`),
   - choose an OTLP transport protocol (`http/json` or `http/protobuf`),
+  - set the `auth` scheme your collector requires (see [Exporter authentication](#exporter-authentication)),
   - define a service name (will be displayed as span service),
   - define an optional root span prefix (will be added in Node-RED root span name),
   - define nodes that should not send traces (using comma-separated list like `debug,catch`),
   - define nodes that should propagate [W3C trace context](https://www.w3.org/TR/trace-context/#design-overview) (in http request headers, using comma-separated list like `http request,my-custom-node`),
   - define time in seconds after which an unmodified message will be ended and deleted,
   - define custom attributes you want to send (optionally).
+
+### Exporter authentication
+
+Most hosted collectors require credentials. Pick an `auth` scheme on the OTEL node:
+
+| Scheme | Header sent |
+| --- | --- |
+| `None` | none |
+| `Bearer token` | `Authorization: Bearer <token>` |
+| `Basic` | `Authorization: Basic <base64 of user:password>` |
+| `Custom header` | `<header name>: <value>`, for example `x-api-key: ...` |
+
+The secret is kept in the [node credentials](https://nodered.org/docs/creating-nodes/credentials), so it is stored apart from the flow: it does not end up in `flows.json`, nor in a flow you export or commit.
+
+Collectors that also want non-secret headers (a dataset, organization or stream name) can be served with `additional exporter headers`.
+
+Headers set in the `OTEL_EXPORTER_OTLP_HEADERS` environment variable are still sent, which is convenient for container deployments:
+
+``` bash
+OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic cm9vdDpwYXNz,x-tenant=acme"
+```
+
+A header configured on the node wins over the environment for the same name.
 
 ### Metrics
 

--- a/lib/opentelemetry-node.html
+++ b/lib/opentelemetry-node.html
@@ -178,7 +178,9 @@ RED.nodes.registerType('OpenTelemetry', {
       sortable: false,
       removable: true,
     })
-    this.headers
+    // a node saved before this field existed has no headers at all: the editor only fills
+    // defaults in on import, not when loading the flows it already has
+    ;(this.headers ?? [])
       .forEach((header) => {
         $('#node-input-otelHeader-container').editableList('addItem', { header })
       })
@@ -222,8 +224,8 @@ RED.nodes.registerType('OpenTelemetry', {
       sortable: false,
       removable: true,
     })
-    // sort and display attributes
-    this.attributeMappings
+    // sort and display attributes, tolerating a node saved before the field existed
+    ;(this.attributeMappings ?? [])
       .sort(sortAttributeMappings)
       .forEach((attributeMapping) => {
         $('#node-input-otelAttributeMapping-container').editableList('addItem', { attributeMapping })

--- a/lib/opentelemetry-node.html
+++ b/lib/opentelemetry-node.html
@@ -10,6 +10,13 @@
   .node-input-otelAttributeMapping-isAfterProcess {
     width: 60px !important;
   }
+  .node-input-otelHeader {
+    flex-grow: 1 !important;
+  }
+  .node-input-otelHeader input {
+    width: calc(50% - 5px) !important;
+    margin-left: 5px !important;
+  }
 </style>
 <script type="text/javascript">
 function sortAttributeMappings (a, b) {
@@ -51,6 +58,39 @@ RED.nodes.registerType('OpenTelemetry', {
       value: 'http',
       required: true,
     },
+    authScheme: {
+      value: 'none',
+      required: true,
+    },
+    authHeaderName: {
+      value: '',
+      validate: function (v) {
+        // only meaningful for the header scheme, where it must be a valid header name
+        if (this.authScheme !== 'header') {
+          return true
+        }
+        return /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(v || '')
+      },
+    },
+    headers: {
+      value: [],
+      validate: function (headers) {
+        if (!headers || headers.length === 0) {
+          return true
+        }
+        const errors = []
+        headers.forEach((header) => {
+          if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(header.key || '')) {
+            errors.push(`"${header.key}" is not a valid header name`)
+          }
+        })
+        if (errors.length) {
+          console.warn(errors.join(', '))
+          return errors
+        }
+        return true
+      },
+    },
     rootPrefix: {
       value: 'Message ',
     },
@@ -90,10 +130,59 @@ RED.nodes.registerType('OpenTelemetry', {
       },
     },
   },
+  credentials: {
+    token: {
+      type: 'password',
+    },
+    username: {
+      type: 'text',
+    },
+    password: {
+      type: 'password',
+    },
+  },
   label: function () {
     return this.name || 'OpenTelemetry'
   },
   oneditprepare: function () {
+    // only show the fields the selected authentication scheme actually needs
+    const showAuthFields = function () {
+      const scheme = $('#node-input-authScheme').val()
+      // the secret field is shared by the bearer and custom header schemes
+      $('.node-input-otelAuth-token').toggle(scheme === 'bearer' || scheme === 'header')
+      $('#node-input-otelAuth-tokenLabel').text(scheme === 'header' ? 'Value' : 'Token')
+      $('.node-input-otelAuth-basic').toggle(scheme === 'basic')
+      $('.node-input-otelAuth-header').toggle(scheme === 'header')
+    }
+    $('#node-input-authScheme').on('change', showAuthFields)
+    showAuthFields()
+
+    $('#node-input-otelHeader-container').css('min-height', '90px').css('min-width', '450px').editableList({
+      addItem: function (container, i, opt) {
+        if (!Object.prototype.hasOwnProperty.call(opt, 'header')) {
+          opt.header = { key: '', value: '' }
+        }
+        container.css({
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          display: 'flex',
+        })
+        container.append(
+          $('<div/>', { class: 'node-input-otelHeader' })
+            .append(
+              $('<input/>', { class: 'node-input-otelHeader-key', type: 'text', placeholder: 'Header name', title: 'Header name', value: opt.header.key }),
+              $('<input/>', { class: 'node-input-otelHeader-value', type: 'text', placeholder: 'Header value', title: 'Header value, do not put a secret here: use the authentication fields above', value: opt.header.value }),
+            ),
+        )
+      },
+      sortable: false,
+      removable: true,
+    })
+    this.headers
+      .forEach((header) => {
+        $('#node-input-otelHeader-container').editableList('addItem', { header })
+      })
+
     $('#node-input-otelAttributeMapping-container').css('min-height', '150px').css('min-width', '450px').editableList({
       addItem: function (container, i, opt) {
         if (!Object.prototype.hasOwnProperty.call(opt, 'attributeMapping')) {
@@ -141,6 +230,15 @@ RED.nodes.registerType('OpenTelemetry', {
       })
   },
   oneditsave: function () {
+    const headers = []
+    $('#node-input-otelHeader-container').editableList('items').each(function () {
+      const key = this.find('.node-input-otelHeader-key').val().trim()
+      if (key !== '') {
+        headers.push({ key, value: this.find('.node-input-otelHeader-value').val() })
+      }
+    })
+    this.headers = headers
+
     const attributeMappings = []
     $('#node-input-otelAttributeMapping-container').editableList('items').each(function () {
       attributeMappings.push({
@@ -173,6 +271,31 @@ RED.nodes.registerType('OpenTelemetry', {
       <option value="proto">http/protobuf</option>
     </select>
   </div>
+  <div class="form-row" title="How to authenticate against the exporter">
+    <label for="node-input-authScheme"><i class="fa fa-lock"></i> Auth</label>
+    <select id="node-input-authScheme">
+      <option value="none">None</option>
+      <option value="bearer">Bearer token</option>
+      <option value="basic">Basic (user and password)</option>
+      <option value="header">Custom header</option>
+    </select>
+  </div>
+  <div class="form-row node-input-otelAuth-header" title="Name of the header carrying the secret, for example x-api-key">
+    <label for="node-input-authHeaderName"><i class="fa fa-tag"></i> Header</label>
+    <input type="text" id="node-input-authHeaderName" placeholder="x-api-key">
+  </div>
+  <div class="form-row node-input-otelAuth-token" title="Stored with the node credentials, kept out of the flow">
+    <label for="node-input-token"><i class="fa fa-key"></i> <span id="node-input-otelAuth-tokenLabel">Token</span></label>
+    <input type="password" id="node-input-token" placeholder="Token">
+  </div>
+  <div class="form-row node-input-otelAuth-basic" title="Stored with the node credentials, kept out of the flow">
+    <label for="node-input-username"><i class="fa fa-user"></i> User</label>
+    <input type="text" id="node-input-username" placeholder="User">
+  </div>
+  <div class="form-row node-input-otelAuth-basic" title="Stored with the node credentials, kept out of the flow">
+    <label for="node-input-password"><i class="fa fa-key"></i> Password</label>
+    <input type="password" id="node-input-password" placeholder="Password">
+  </div>
   <div class="form-row" title="OpenTelemetry service name">
     <label for="node-input-serviceName"><i class="fa fa-server"></i> Service</label>
     <input type="text" id="node-input-serviceName" placeholder="Node-RED">
@@ -198,6 +321,13 @@ RED.nodes.registerType('OpenTelemetry', {
     <input type="checkbox" id="node-input-isLogging" style="display: inline-block; width: auto; vertical-align: top;">
   </div>
   <hr/>
+  <div class="form-row" style="margin-bottom:0;" title="Additional headers required by some collectors (dataset, organization, stream, ...). Do not put secrets here, use the authentication fields above.">
+    <label style="width: 100%;"><i class="fa fa-list"></i> <span> Additional exporter headers</span></label>
+  </div>
+  <div class="form-row node-input-otelHeader-container-row">
+    <ol id="node-input-otelHeader-container"></ol>
+  </div>
+  <hr/>
   <div class="form-row" style="margin-bottom:0;">
     <label style="width: 100%;"><i class="fa fa-list"></i> <span> Span attribute mappings</span></label>
   </div>
@@ -217,6 +347,15 @@ RED.nodes.registerType('OpenTelemetry', {
     <li>optional comma-separated list of <code>ignored</code> nodes that will not emit a trace,</li>
     <li>optional comma-separated list of node types that will <code>propagate</code> traces using request headers (W3C trace context propagation).</li>
   </ul></p>
+  <h3>Authentication</h3>
+  <p>Most hosted collectors require credentials. Pick an <code>auth</code> scheme:<ul>
+    <li><code>Bearer token</code> sends <code>Authorization: Bearer &lt;token&gt;</code>,</li>
+    <li><code>Basic</code> sends <code>Authorization: Basic &lt;base64 of user:password&gt;</code>,</li>
+    <li><code>Custom header</code> sends the value under the header name you give, for example <code>x-api-key</code>.</li>
+  </ul></p>
+  <p>The secret is stored with the node credentials, so it stays out of <code>flows.json</code> and out of any flow you export or commit.</p>
+  <p>Collectors asking for extra non-secret headers (a dataset, organization or stream name) can be served with <code>additional exporter headers</code>.</p>
+  <p>Headers set in the <code>OTEL_EXPORTER_OTLP_HEADERS</code> environment variable are still sent, which is handy for container deployments. A header configured here wins over the environment for the same name.</p>
   <p>You can add your own attributes to the generated spans by adding:<ul>
     <li>the <code>flow</code> identifier involved (you can leave this field empty to use in all flows),</li>
     <li>the <code>nodeType</code> involved (examples: <code>http in</code>, <code>http request</code>, <code>file in</code>, ... , you can leave this field empty to use in all node types),</li>

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -464,6 +464,63 @@ function endSpan (msg, error, nodeDefinition) {
   }
 }
 
+/**
+ * Build the headers the exporter has to send, from the configured authentication and the
+ * additional headers some collectors require (dataset, organization, stream, ...).
+ *
+ * Secrets live in the node credentials, never in the flow configuration, so they stay out of
+ * `flows.json` and out of any exported flow. Headers set in `OTEL_EXPORTER_OTLP_HEADERS` are
+ * merged by the SDK itself; a header defined here wins over the environment for the same key.
+ *
+ * @param {any} config Node configuration
+ * @param {any} credentials Node credentials
+ * @param {any} node OTEL node, warned when the configuration is incomplete
+ * @returns {Record<string, string>} Headers to add to the exporter requests
+ */
+function getExporterHeaders (config, credentials, node) {
+  const { authScheme, authHeaderName, headers: additionalHeaders } = config
+  const headers = {}
+
+  ;(additionalHeaders ?? []).forEach((header) => {
+    if (header && header.key) {
+      // eslint-disable-next-line security/detect-object-injection
+      headers[header.key] = header.value ?? ''
+    }
+  })
+
+  const { token, username, password } = credentials ?? {}
+  switch (authScheme) {
+    case 'bearer':
+      if (!token) {
+        node.warn('Bearer authentication is selected but no token is set, requests will be sent unauthenticated')
+        break
+      }
+      headers.authorization = `Bearer ${token}`
+      break
+
+    case 'basic':
+      if (!username && !password) {
+        node.warn('Basic authentication is selected but no user and no password are set, requests will be sent unauthenticated')
+        break
+      }
+      headers.authorization = `Basic ${Buffer.from(`${username ?? ''}:${password ?? ''}`).toString('base64')}`
+      break
+
+    case 'header':
+      if (!authHeaderName || !token) {
+        node.warn('Header authentication is selected but the header name or its value is missing, requests will be sent unauthenticated')
+        break
+      }
+      // eslint-disable-next-line security/detect-object-injection
+      headers[authHeaderName] = token
+      break
+
+    default:
+      break
+  }
+  return headers
+}
+
 module.exports = function (RED) {
   'use strict'
 
@@ -486,14 +543,20 @@ module.exports = function (RED) {
     }
     const node = this
 
+    // authentication and any additional headers the collector requires
+    const headers = getExporterHeaders(config, this.credentials, node)
+    if (Object.keys(headers).length > 0 && url.startsWith('http://') && !/^http:\/\/(localhost|127\.0\.0\.1|\[::1\])[:/]/.test(url)) {
+      node.warn('Exporter headers are sent over plain http, they can be read in transit: use https for a remote collector')
+    }
+
     // create tracer
     let spanProcessor
     if (protocol === 'proto') {
       const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto')
-      spanProcessor = new BatchSpanProcessor(new OTLPTraceExporter({ url }))
+      spanProcessor = new BatchSpanProcessor(new OTLPTraceExporter({ url, headers }))
     } else {
       const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
-      spanProcessor = new BatchSpanProcessor(new OTLPTraceExporter({ url }))
+      spanProcessor = new BatchSpanProcessor(new OTLPTraceExporter({ url, headers }))
     }
     const provider = new BasicTracerProvider({
       resource: new Resource({
@@ -602,5 +665,12 @@ module.exports = function (RED) {
     this.status({ fill: 'green', shape: 'ring', text: url })
   }
 
-  RED.nodes.registerType('OpenTelemetry', OpenTelemetryNode)
+  // credentials are stored apart from the flow, so tokens never end up in `flows.json`
+  RED.nodes.registerType('OpenTelemetry', OpenTelemetryNode, {
+    credentials: {
+      token: { type: 'password' },
+      username: { type: 'text' },
+      password: { type: 'password' },
+    },
+  })
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.6.4",
   "description": "Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for Node-RED",
   "scripts": {
-    "lint": "eslint . --fix"
+    "lint": "eslint . --fix",
+    "test": "node --test --test-force-exit \"test/**/*.test.js\""
   },
   "engines": {
     "node": ">=18.0.0"

--- a/test/editor-dialog.test.js
+++ b/test/editor-dialog.test.js
@@ -1,0 +1,84 @@
+/**
+ * The edit dialog, exercised against stubs for jQuery and the Node-RED editor.
+ *
+ * `oneditprepare` builds two editable lists. If it throws part way through, every list after
+ * the failure is left uninitialised and the dialog silently loses those sections, so what
+ * matters here is that it survives a node whose newer properties are missing: the editor only
+ * fills defaults in on import, not when loading the flows it already has
+ * (`applyNodeDefaults` defaults to false).
+ */
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const vm = require('node:vm')
+
+/** Load the editor script out of the node's html file and return the registered definition */
+function loadNodeDefinition () {
+  const html = fs.readFileSync(path.join(__dirname, '..', 'lib', 'opentelemetry-node.html'), 'utf8')
+  const script = /<script type="text\/javascript">([\s\S]*?)<\/script>/.exec(html)
+  assert.ok(script, 'the html must hold an editor script')
+
+  const registered = {}
+  const initialised = []
+  // the selector is kept out of the proxy, whose get trap would turn it back into a function
+  let currentSelector = null
+  const chain = new Proxy({}, {
+    get (_target, property) {
+      return (...args) => {
+        if (property === 'editableList' && typeof args[0] === 'object') {
+          // the list is being set up, rather than being appended to
+          initialised.push(currentSelector)
+        }
+        if (property === 'val') {
+          return 'none'
+        }
+        if (property === 'items') {
+          return { each: () => chain }
+        }
+        return chain
+      }
+    },
+  })
+  const $ = (selector) => {
+    currentSelector = selector
+    return chain
+  }
+  const sandbox = {
+    // eslint-disable-next-line security/detect-object-injection
+    RED: { nodes: { registerType: (type, definition) => { registered[type] = definition } } },
+    $,
+    console,
+  }
+  vm.createContext(sandbox)
+  vm.runInContext(script[1], sandbox)
+  return { definition: registered.OpenTelemetry, initialised }
+}
+
+test('the edit dialog builds both lists for a node that has every property', () => {
+  const { definition, initialised } = loadNodeDefinition()
+  definition.oneditprepare.call({ headers: [{ key: 'x-tenant', value: 'acme' }], attributeMappings: [] })
+  assert.ok(initialised.includes('#node-input-otelHeader-container'))
+  assert.ok(initialised.includes('#node-input-otelAttributeMapping-container'))
+})
+
+test('the edit dialog survives a node saved before the newer fields existed', () => {
+  const { definition, initialised } = loadNodeDefinition()
+  // exactly what the editor hands over for a config node stored by an older version
+  definition.oneditprepare.call({ headers: undefined, attributeMappings: undefined })
+  assert.ok(initialised.includes('#node-input-otelHeader-container'), 'headers list must still be built')
+  assert.ok(
+    initialised.includes('#node-input-otelAttributeMapping-container'),
+    'the span attribute mappings list must still be built: it is set up after the headers one, ' +
+    'so anything throwing earlier makes that section disappear from the dialog',
+  )
+})
+
+test('saving collects both lists without touching the flow', () => {
+  const { definition } = loadNodeDefinition()
+  const node = {}
+  definition.oneditsave.call(node)
+  // compared as JSON: arrays built inside the vm realm are not reference-equal to host ones
+  assert.equal(JSON.stringify(node.headers), '[]')
+  assert.equal(JSON.stringify(node.attributeMappings), '[]')
+})

--- a/test/exporter-auth.test.js
+++ b/test/exporter-auth.test.js
@@ -1,0 +1,187 @@
+/**
+ * Exporter authentication, checked against a real OTLP request.
+ *
+ * The exporter is the real one here, so the assertions are on the headers a collector actually
+ * receives rather than on how the node was configured.
+ */
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const http = require('node:http')
+
+const DEFAULT_CONFIG = {
+  protocol: 'http',
+  serviceName: 'test',
+  rootPrefix: 'Message ',
+  ignoredTypes: 'debug,catch',
+  propagateHeadersTypes: '',
+  isLogging: false,
+  timeout: 10,
+  attributeMappings: [],
+  authScheme: 'none',
+  authHeaderName: '',
+  headers: [],
+}
+
+let messageCounter = 0
+
+/** A collector recording what it receives */
+function startCollector () {
+  const requests = []
+  let notify = null
+  const server = http.createServer((req, res) => {
+    req.resume()
+    req.on('end', () => {
+      requests.push({ headers: req.headers })
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end('{}')
+      if (notify) {
+        const resolve = notify
+        notify = null
+        resolve()
+      }
+    })
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        url: `http://127.0.0.1:${server.address().port}/v1/traces`,
+        requests,
+        /** Resolves once one export request has been handled */
+        received: () => new Promise((resolve) => { notify = resolve }),
+        close: () => new Promise((resolve) => server.close(resolve)),
+      })
+    })
+  })
+}
+
+/**
+ * Instantiate the OpenTelemetry node against a stubbed Node-RED runtime
+ * @param {object} config Configuration overrides
+ * @param {object} [credentials] Node credentials
+ */
+function startNode (config, credentials = {}) {
+  const hooks = {}
+  const warnings = []
+  let closeHandler
+  let constructNode
+  const RED = {
+    nodes: {
+      createNode: (node) => {
+        node.credentials = credentials
+        node.status = () => {}
+        node.warn = (warning) => warnings.push(warning)
+        node.on = (event, callback) => {
+          if (event === 'close') {
+            closeHandler = callback.bind(node)
+          }
+        }
+      },
+      registerType: (_type, constructor) => {
+        constructNode = constructor
+      },
+    },
+    hooks: {
+      add: (name, handler) => { hooks[name.split('.')[0]] = handler },
+      remove: () => {},
+    },
+  }
+  require('../lib/opentelemetry-node')(RED)
+  const node = { id: 'otel-node' }
+  constructNode.call(node, { ...DEFAULT_CONFIG, ...config })
+
+  return {
+    warnings,
+    /** Run a message through one node, which produces spans to export */
+    trace: () => {
+      const msg = { _msgid: `msgid-${++messageCounter}`, payload: 1 }
+      const traced = { id: 'traced-node', type: 'inject', name: '', z: 'flow-1' }
+      hooks.onSend([{ msg, source: { id: traced.id, node: traced, port: 0 }, destination: { id: 'next', node: undefined } }])
+      hooks.onComplete({ msg, error: undefined, node: { id: traced.id, node: traced } })
+    },
+    /** Shutting the node down flushes the span processor */
+    stop: () => closeHandler(),
+  }
+}
+
+/**
+ * Export one span and return the headers the collector saw
+ * @param {object} config Configuration overrides
+ * @param {object} [credentials] Node credentials
+ */
+async function exportedHeaders (config, credentials) {
+  const collector = await startCollector()
+  const node = startNode({ ...config, url: collector.url }, credentials)
+  node.trace()
+  const received = collector.received()
+  await node.stop()
+  await received
+  await collector.close()
+  assert.equal(collector.requests.length, 1, 'the collector must have received one export request')
+  return { headers: collector.requests[0].headers, warnings: node.warnings }
+}
+
+test('no authentication sends no authorization header', async () => {
+  const { headers } = await exportedHeaders({ authScheme: 'none' })
+  assert.equal(headers.authorization, undefined)
+})
+
+test('a bearer token is sent as an authorization header', async () => {
+  const { headers } = await exportedHeaders({ authScheme: 'bearer' }, { token: 'sekret-token' })
+  assert.equal(headers.authorization, 'Bearer sekret-token')
+})
+
+test('basic credentials are sent base64 encoded', async () => {
+  const { headers } = await exportedHeaders({ authScheme: 'basic' }, { username: 'root@example.com', password: 'pa:ss word' })
+  assert.equal(headers.authorization, `Basic ${Buffer.from('root@example.com:pa:ss word').toString('base64')}`)
+})
+
+test('a custom header carries the secret under the configured name', async () => {
+  const { headers } = await exportedHeaders({ authScheme: 'header', authHeaderName: 'x-api-key' }, { token: 'abc123' })
+  assert.equal(headers['x-api-key'], 'abc123')
+  assert.equal(headers.authorization, undefined)
+})
+
+test('additional headers are sent alongside the authentication', async () => {
+  const { headers } = await exportedHeaders({
+    authScheme: 'bearer',
+    headers: [{ key: 'x-dataset', value: 'production' }, { key: 'x-tenant', value: 'acme' }],
+  }, { token: 'tok' })
+  assert.equal(headers.authorization, 'Bearer tok')
+  assert.equal(headers['x-dataset'], 'production')
+  assert.equal(headers['x-tenant'], 'acme')
+})
+
+test('an incomplete authentication configuration warns instead of sending a broken header', async () => {
+  const { headers, warnings } = await exportedHeaders({ authScheme: 'bearer' }, {})
+  assert.equal(headers.authorization, undefined, 'no header rather than "Bearer undefined"')
+  assert.match(warnings.join(' '), /no token is set/)
+})
+
+test('a header name without a value warns instead of sending it', async () => {
+  const { headers, warnings } = await exportedHeaders({ authScheme: 'header', authHeaderName: 'x-api-key' }, {})
+  assert.equal(headers['x-api-key'], undefined)
+  assert.match(warnings.join(' '), /header name or its value is missing/)
+})
+
+test('a local collector over plain http is not warned about', async () => {
+  // the collector in these tests is on 127.0.0.1, which is exempt
+  const { warnings } = await exportedHeaders({ authScheme: 'bearer' }, { token: 'tok' })
+  assert.deepEqual(warnings, [])
+})
+
+test('credentials sent over plain http to a remote collector are warned about', async () => {
+  // no span is exported here, so nothing leaves the machine: the warning is raised on startup
+  const node = startNode({ url: 'http://collector.example.com:4318/v1/traces', authScheme: 'bearer' }, { token: 'tok' })
+  assert.match(node.warnings.join(' '), /sent over plain http/)
+  await node.stop()
+})
+
+test('no warning is raised over https, nor without credentials', async () => {
+  const secure = startNode({ url: 'https://collector.example.com/v1/traces', authScheme: 'bearer' }, { token: 'tok' })
+  assert.deepEqual(secure.warnings, [])
+  await secure.stop()
+
+  const anonymous = startNode({ url: 'http://collector.example.com/v1/traces', authScheme: 'none' })
+  assert.deepEqual(anonymous.warnings, [])
+  await anonymous.stop()
+})


### PR DESCRIPTION
Closes #21.

A collector that needs credentials could not be used at all: the exporter was built from the url alone, so there was no way to send an `Authorization` header or an api key.

## What this adds

An `auth` scheme on the OTEL node:

| Scheme | Header sent |
| --- | --- |
| `None` (default) | none |
| `Bearer token` | `Authorization: Bearer <token>` |
| `Basic` | `Authorization: Basic <base64 of user:password>` |
| `Custom header` | `<header name>: <value>`, for api key style collectors |

Plus an `additional exporter headers` list for the non-secret headers some collectors want alongside the credentials (dataset, organization, stream name) — OpenObserve in the original discussion, and the same pattern covers Honeycomb, Dash0 and Grafana Cloud.

## Secrets go in credentials, not in the configuration

The sketch in #21 puts the header in the node configuration. That would write the token into `flows.json`, so it would travel with every flow export, backup and commit of the flow.

This uses [node credentials](https://nodered.org/docs/creating-nodes/credentials) instead, so the secret is stored apart from the flow and stripped from exports. Only the non-secret parts — the scheme, the header name, the additional headers — live in the configuration.

## Environment variables still work

`OTEL_EXPORTER_OTLP_HEADERS` is read by the SDK itself and keeps working, which stays convenient for container deployments where the token comes from the environment:

```bash
OTEL_EXPORTER_OTLP_HEADERS="authorization=Basic cm9vdDpwYXNz,x-tenant=acme"
```

I checked the precedence against a real request rather than assuming it: a header configured on the node wins over the environment for the same name, and environment-only headers are still merged in. Both are documented in the README.

## Two guards

- Selecting a scheme without filling in its secret warns and sends **no** header, instead of sending the string `Bearer undefined` and getting an opaque 401 from the collector.
- Sending credentials over plain `http://` to a collector that is not on localhost warns once at startup. Drop this if you find it noisy — it is three lines and easy to remove.

## Tests

`npm test` (`node:test`, no new dependencies). The exporter is the **real** one here: the tests start a local collector and assert on the headers it actually receives, so they cover the wiring into the exporter and not just the header-building function.

```
✔ no authentication sends no authorization header
✔ a bearer token is sent as an authorization header
✔ basic credentials are sent base64 encoded
✔ a custom header carries the secret under the configured name
✔ additional headers are sent alongside the authentication
✔ an incomplete authentication configuration warns instead of sending a broken header
✔ a header name without a value warns instead of sending it
✔ a local collector over plain http is not warned about
✔ credentials sent over plain http to a remote collector are warned about
✔ no warning is raised over https, nor without credentials
```

`npm run lint` is clean, and `test/` is excluded from the published package.

## Notes for review

- Only the trace exporter is touched. The Prometheus node is scraped rather than pushing, so it has nothing to authenticate.
- mTLS (client certificates) is not covered; it needs an https agent rather than headers, so it seemed better kept separate.
- This branches from `master` and is independent of #32, but both add a `test` script and a `test` entry to `.npmignore`, so whichever merges second will conflict trivially on those two lines.
