### PR TITLE
fix(trace): keep a fan out from an entry node in one trace

### DIFF
--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -37,6 +37,8 @@ const jmespath = require('jmespath')
  * @property {number} pending Number of open node spans (the root ends when this reaches 0)
  * @property {number} updateTimestamp
  * @property {boolean} ended
+ * @property {NodeJS.Immediate} [finishTimer] Pending end of run check, see scheduleFinishRun
+ * @property {number} [quietSince] When the last node span ended, used as the run end time
  *
  * @typedef {object} NodeState What a node is currently working on
  * @property {string} runId
@@ -417,6 +419,33 @@ function getOrCreateRun (tracer, msg, nodeDefinition, candidateIds) {
 }
 
 /**
+ * Ask for a run to be closed once the current batch of work has settled.
+ *
+ * A node sends to every one of its wires from a single `send()`, and the runtime delivers them
+ * one at a time, so there are moments during that loop where no span is open yet the run is far
+ * from over: the next wire is dispatched but its span does not exist yet. Ending the run there
+ * would cut the execution in two. Every `preDeliver`/`postDeliver` of one send happens in the
+ * same turn, so the check is deferred to the end of it, and the run is ended at the moment it
+ * really went quiet rather than a tick later.
+ *
+ * @param {Run} run Run whose last node span just ended
+ */
+function scheduleFinishRun (run) {
+  if (run.ended || run.finishTimer !== undefined) {
+    return
+  }
+  run.quietSince = Date.now()
+  run.finishTimer = setImmediate(() => {
+    run.finishTimer = undefined
+    // more work arrived while we waited, or the run is already gone
+    if (run.pending > 0 || runs.get(run.id) !== run) {
+      return
+    }
+    finishRun(run, run.quietSince)
+  })
+}
+
+/**
  * End the root span of a run, keeping its context available for linking a continuation
  * @param {Run} run Run to close
  * @param {number} [endTime] Explicit end timestamp (used when closing an abandoned run)
@@ -424,6 +453,10 @@ function getOrCreateRun (tracer, msg, nodeDefinition, candidateIds) {
 function finishRun (run, endTime) {
   if (run.ended) {
     return
+  }
+  if (run.finishTimer !== undefined) {
+    clearImmediate(run.finishTimer)
+    run.finishTimer = undefined
   }
   run.ended = true
   run.rootSpan.end(endTime)
@@ -463,7 +496,7 @@ function endChildSpan (run, spanKey, endTime) {
   run.pending = Math.max(0, run.pending - 1)
   run.updateTimestamp = Date.now()
   if (run.pending === 0) {
-    finishRun(run)
+    scheduleFinishRun(run)
   }
 }
 
@@ -942,6 +975,11 @@ module.exports = function (RED) {
       }
       RED.hooks.remove('*.otel')
       activeNodeId = null
+      for (const run of runs.values()) {
+        if (run.finishTimer !== undefined) {
+          clearImmediate(run.finishTimer)
+        }
+      }
       runs.clear()
       nodeStates.clear()
       endedRuns.clear()

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -279,6 +279,9 @@ class MiniRed {
    * @returns {Promise<import('@opentelemetry/sdk-trace-base').ReadableSpan[]>}
    */
   async stop () {
+    // a run is closed once the current turn has settled, so give the runtime that turn before
+    // shutting down, exactly as it would get between two deliveries
+    await settle()
     await this.closeHandler()
     return exportedSpans.slice()
   }
@@ -289,4 +292,9 @@ function sleep (ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-module.exports = { MiniRed, sleep, nextMsgId }
+/** Let the current turn finish, which is when a quiet run gets closed */
+function settle () {
+  return new Promise((resolve) => setImmediate(resolve))
+}
+
+module.exports = { MiniRed, sleep, settle, nextMsgId }

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -1,6 +1,6 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
-const { MiniRed, sleep } = require('./helpers/mini-red')
+const { MiniRed, sleep, settle } = require('./helpers/mini-red')
 
 /** ReadableSpan exposes the parent as `parentSpanId` (SDK 1.x) or `parentSpanContext` (2.x) */
 function parentSpanIdOf (span) {
@@ -189,7 +189,9 @@ test('a message emitted after the run finished starts a linked trace', async () 
 
   red.send(inject, { payload: 1 })
   red.run()
-  // the queued message is released once the first run is already over
+  // a delay node emits on a timer, so the release lands in a later turn, by which point the
+  // first run has gone quiet and been closed
+  await settle()
   red.send(delay, { payload: 'released' })
   red.run()
   const spans = await red.stop()
@@ -574,4 +576,73 @@ test('an inject started run is labelled by its own trigger type', async () => {
   const spans = await red.stop()
 
   assert.equal(rootOf(spans).attributes['node_red.trigger.type'], 'inject')
+})
+
+/**
+ * A node sends to all of its wires from one `send()`, and the runtime delivers them one at a
+ * time. An entry node's span is closed on delivery, since it never reports completion, so the
+ * run must not be declared over while the later wires of that same send are still to come.
+ * @param {object} options
+ * @param {string} options.ignoredTypes Node types excluded from tracing
+ * @param {boolean} options.debugFirst Is the ignored node the first wire?
+ */
+async function fanOutFromEntryNode ({ ignoredTypes, debugFirst }) {
+  const red = new MiniRed({ ignoredTypes })
+  const mqtt = red.node('n1', 'mqtt in', { name: 'home/sensor/pool/pump' })
+  const raw = red.node('n2', 'debug', { name: 'Raw pump message' })
+  const stamp = red.node('n3', 'change', { name: 'Set timestamp' })
+  const store = red.node('n4', 'influxdb out', { name: 'Save pump data' })
+  red.wire(mqtt, debugFirst ? [raw, stamp] : [stamp, raw])
+  red.wire(stamp, [store])
+  red.on(store, (msg, send, done) => done())
+
+  red.send(mqtt, { payload: { power: 900 } })
+  red.run()
+  return red.stop()
+}
+
+test('an entry node fanning out to an untraced node first stays one trace', async () => {
+  // the untraced node produces no span, so nothing else was open at that instant
+  const spans = await fanOutFromEntryNode({ ignoredTypes: 'debug,catch', debugFirst: true })
+
+  assert.equal(traceIdsOf(spans).size, 1, 'the whole execution must be one trace')
+  const root = rootOf(spans)
+  assert.equal(root.name, 'Message home/sensor/pool/pump')
+  assert.equal(root.links.length, 0, 'a fan out is not an asynchronous hand off, so no link')
+  for (const name of ['home/sensor/pool/pump', 'Set timestamp', 'Save pump data']) {
+    assert.equal(byName(spans, name).length, 1, `${name} must be in the trace`)
+    assert.equal(parentSpanIdOf(byName(spans, name)[0]), root.spanContext().spanId)
+  }
+})
+
+test('the wiring order of an untraced node does not change the trace', async () => {
+  // this used to differ: only the first ordering split the execution in two
+  const first = await fanOutFromEntryNode({ ignoredTypes: 'debug,catch', debugFirst: true })
+  const second = await fanOutFromEntryNode({ ignoredTypes: 'debug,catch', debugFirst: false })
+  const tracedToo = await fanOutFromEntryNode({ ignoredTypes: '', debugFirst: true })
+
+  assert.equal(traceIdsOf(first).size, 1)
+  assert.equal(traceIdsOf(second).size, 1)
+  assert.equal(traceIdsOf(tracedToo).size, 1)
+  assert.deepEqual(
+    first.map((span) => span.name).sort(),
+    second.map((span) => span.name).sort(),
+    'the same flow must produce the same spans whichever wire comes first',
+  )
+})
+
+test('an entry node whose only wire is untraced still closes its run', async () => {
+  const red = new MiniRed()
+  const mqtt = red.node('n1', 'mqtt in', { name: 'pump' })
+  const raw = red.node('n2', 'debug')
+  red.wire(mqtt, [raw])
+
+  red.send(mqtt, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  // nothing follows, so the run really is over: it must still be exported, not left hanging
+  assert.equal(traceIdsOf(spans).size, 1)
+  assert.equal(byName(spans, 'pump').length, 1)
+  assert.equal(spans.filter((span) => span.attributes['node_red.span.incomplete']).length, 0)
 })


### PR DESCRIPTION
Fixes the two traces reported in #34.

`mqtt in` is a source: the publish arrives through the subscribe callback and the node calls `node.send()`, so that message never goes through `receive()` and never reports completion. Its span is therefore closed on delivery instead.

But a node sends to all of its wires from a single `send()` and the runtime delivers them one at a time. In the reported flow the first wire goes to a `debug` node, which is in `ignoredTypes` and so produces no span: at that instant nothing was open, the run was declared finished, and the second wire had no run to join, so it started a new one linked to the first.

It was wiring-order dependent — moving the debug wire to second made the same flow produce a single trace.

The end of run check is now deferred to the end of the current turn, by which point the later wires of the same send have their spans. The run is still ended at the moment it went quiet, so span durations are unchanged, and the timeout sweep still takes precedence.

Three tests added, one of which asserts that swapping the wiring order produces an identical set of spans, since that was the property being violated. `npm test` is green (32) and `npm run lint` is clean.
