### PR TITLE
feat(trace): optionally nest node spans by what sent to what

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
 
 #### What is a _run span_?
 
-A trace corresponds to an execution of your flow. The first node to emit a message opens a **run span**, each node reached by the message becomes a child span, and the run span ends when the last of those node spans ends. The run span carries `node_red.trigger.type`, which is the type of the node that triggered the execution. This allows a collector to route or filter it without having to read the spans of the individual nodes.
+A trace corresponds to an execution of your flow. The first node to emit a message opens a **run span**, each node reached by the message becomes a span, and the run span ends when the last of those node spans ends.
+
+By default every node span is a child of the run span, which gives a flat timeline that reads easily and shows at a glance where the time went. Tick **nest spans** to make a node span a child of the span of the node that sent it the message instead, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper waterfall. A chain deeper than 50 restarts from the run span, so a long loop cannot bury itself. The run span carries `node_red.trigger.type`, which is the type of the node that triggered the execution. This allows a collector to route or filter it without having to read the spans of the individual nodes.
 
 Node-RED gives a fresh `_msgid` to every message object a node emits (a `function` node returning `{payload: ...}` instead of the message it received, a `split` node, a `join` node, ...). To keep those in the same trace, the run is carried on the message in the `otelRootMsgId` property, which you will therefore see on messages in the debug sidebar.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ Distributed tracing with OpenTelemetry SDK and Prometheus metrics exporter for N
 
 #### What is a _run span_?
 
-A trace corresponds to an execution of your flow. The first node to emit a message opens a **run span**, each node reached by the message becomes a span, and the run span ends when the last of those node spans ends.
+A trace corresponds to an execution of your flow. The first node to emit a message opens a **run span**, each node reached by the message becomes a child span, and the run span ends when the last of those node spans ends. The run span carries `node_red.trigger.type`, which is the type of the node that triggered the execution. This allows a collector to route or filter it without having to read the spans of the individual nodes.
 
-By default every node span is a child of the run span, which gives a flat timeline that reads easily and shows at a glance where the time went. Tick **nest spans** to make a node span a child of the span of the node that sent it the message instead, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper waterfall. A chain deeper than 50 restarts from the run span, so a long loop cannot bury itself. The run span carries `node_red.trigger.type`, which is the type of the node that triggered the execution. This allows a collector to route or filter it without having to read the spans of the individual nodes.
+The run span is the _local root span_: it is the root of the trace unless a trace context arrived with the message, in which case it is a child of the caller's span.
+
+By default every node span is a child of it, which gives a flat timeline that reads easily and shows at a glance where the time went. Tick **nest spans** to make a node span a child of the span of the node that sent it the message instead, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper waterfall. A chain deeper than 50 restarts from the local root span, so a long loop cannot bury itself.
 
 Node-RED gives a fresh `_msgid` to every message object a node emits (a `function` node returning `{payload: ...}` instead of the message it received, a `split` node, a `join` node, ...). To keep those in the same trace, the run is carried on the message in the `otelRootMsgId` property, which you will therefore see on messages in the debug sidebar.
 

--- a/lib/opentelemetry-node.html
+++ b/lib/opentelemetry-node.html
@@ -110,7 +110,7 @@ RED.nodes.registerType('OpenTelemetry', {
     isLogging: {
       value: false,
     },
-    nestSpans: {
+    isNestSpansMode: {
       value: false,
     },
     attributeMappings: {
@@ -328,9 +328,9 @@ RED.nodes.registerType('OpenTelemetry', {
     <label for="node-input-timeout"><i class="fa fa-hourglass"></i> Timeout</label>
     <input type="number" id="node-input-timeout" placeholder="10">
   </div>
-  <div class="form-row" title="Make each node span a child of the node that sent it the message, instead of a child of the run span">
-    <label for="node-input-nestSpans"><i class="fa fa-sitemap"></i> Nest spans</label>
-    <input type="checkbox" id="node-input-nestSpans" style="display: inline-block; width: auto; vertical-align: top;">
+  <div class="form-row" title="Make each node span a child of the node that sent it the message, instead of a child of the local root span">
+    <label for="node-input-isNestSpansMode"><i class="fa fa-sitemap"></i> Nest spans</label>
+    <input type="checkbox" id="node-input-isNestSpansMode" style="display: inline-block; width: auto; vertical-align: top;">
   </div>
   <div class="form-row" title="Send debug logs to the console">
     <label for="node-input-isLogging"><i class="fa fa-bug"></i> Debug log</label>
@@ -381,8 +381,8 @@ RED.nodes.registerType('OpenTelemetry', {
     <li>the <code>path</code> in the processed message object in <a href="https://jmespath.org/" target="_blank" rel="noopener noreferrer">JMESPath syntax</a>, starting after <code>msg.</code> (<code>payload.action</code> for example); alternatively, you can specify the attribute value as a fixed string enclosed in single or double quotes (e.g., <code>"myValue"</code>)</li>
   </ul></p>
   <h3>Span nesting</h3>
-  <p>By default every node span is a child of the run span, which gives a flat timeline that is easy to read and shows at a glance where the time went.</p>
-  <p>With <code>nest spans</code> ticked, a node span is instead a child of the span of the node that sent it the message, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper and busier waterfall. A chain deeper than 50 restarts from the run span, so a long loop cannot bury itself.</p>
+  <p>By default every node span is a child of the local root span, which gives a flat timeline that is easy to read and shows at a glance where the time went.</p>
+  <p>With <code>nest spans</code> ticked, a node span is instead a child of the span of the node that sent it the message, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper and busier waterfall. A chain deeper than 50 restarts from the local root span, so a long loop cannot bury itself.</p>
   <p>This node should only be added once for all your Node-Red flows (regardless of location).</p>
   <h3>References</h3>
   <ul>

--- a/lib/opentelemetry-node.html
+++ b/lib/opentelemetry-node.html
@@ -110,6 +110,9 @@ RED.nodes.registerType('OpenTelemetry', {
     isLogging: {
       value: false,
     },
+    nestSpans: {
+      value: false,
+    },
     attributeMappings: {
       value: [],
       validate: function (attributeMappings) {
@@ -325,6 +328,10 @@ RED.nodes.registerType('OpenTelemetry', {
     <label for="node-input-timeout"><i class="fa fa-hourglass"></i> Timeout</label>
     <input type="number" id="node-input-timeout" placeholder="10">
   </div>
+  <div class="form-row" title="Make each node span a child of the node that sent it the message, instead of a child of the run span">
+    <label for="node-input-nestSpans"><i class="fa fa-sitemap"></i> Nest spans</label>
+    <input type="checkbox" id="node-input-nestSpans" style="display: inline-block; width: auto; vertical-align: top;">
+  </div>
   <div class="form-row" title="Send debug logs to the console">
     <label for="node-input-isLogging"><i class="fa fa-bug"></i> Debug log</label>
     <input type="checkbox" id="node-input-isLogging" style="display: inline-block; width: auto; vertical-align: top;">
@@ -373,6 +380,9 @@ RED.nodes.registerType('OpenTelemetry', {
     <li>an <a href="https://opentelemetry.io/docs/concepts/signals/traces/#attributes" target="_blank" rel="noopener noreferrer">OTEL span attribute <code>key</code></a> (<code>node_red.action</code> for example)</li>
     <li>the <code>path</code> in the processed message object in <a href="https://jmespath.org/" target="_blank" rel="noopener noreferrer">JMESPath syntax</a>, starting after <code>msg.</code> (<code>payload.action</code> for example); alternatively, you can specify the attribute value as a fixed string enclosed in single or double quotes (e.g., <code>"myValue"</code>)</li>
   </ul></p>
+  <h3>Span nesting</h3>
+  <p>By default every node span is a child of the run span, which gives a flat timeline that is easy to read and shows at a glance where the time went.</p>
+  <p>With <code>nest spans</code> ticked, a node span is instead a child of the span of the node that sent it the message, so the trace follows the wiring of your flow. That suits tracking the path a message took, or building a dependency graph, at the cost of a deeper and busier waterfall. A chain deeper than 50 restarts from the run span, so a long loop cannot bury itself.</p>
   <p>This node should only be added once for all your Node-Red flows (regardless of location).</p>
   <h3>References</h3>
   <ul>

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -32,6 +32,9 @@ const jmespath = require('jmespath')
  * @property {Span} rootSpan
  * @property {Context} ctx Context holding the root span, used as parent of every node span
  * @property {Map<string, Span>} spans Open node spans, keyed by `<msgId>#<nodeId>`
+ * @property {Map<string, {ctx: Context, depth: number}>} spanContexts Context of every node span
+ *   created in this run, kept after the span closes so a later wire still nests under it.
+ *   Only filled when span nesting is switched on.
  * @property {Set<string>} ignored Span keys of nodes excluded from tracing
  * @property {Set<string>} entrySpans Span keys of nodes that emitted a message without receiving one
  * @property {number} pending Number of open node spans (the root ends when this reaches 0)
@@ -64,6 +67,15 @@ const ATTR_LINK_TYPE = 'node_red.link.type'
  * it now identifies the whole flow execution instead of only the message that entered a `split` node.
  */
 const RUN_ID_PROPERTY = 'otelRootMsgId'
+
+/**
+ * How deep the parent/child chain may go before a span is attached to the run span instead.
+ * Only relevant when span nesting is switched on.
+ * A flow that loops sends the message round the same nodes again, and each pass would otherwise
+ * nest under the previous one, so a long loop would bury its last iteration under thousands of
+ * levels that no trace viewer can show usefully.
+ */
+const MAX_NESTING_DEPTH = 50
 
 /** Node types that emit messages without receiving one but whose span is closed elsewhere */
 const CORRELATED_ENTRY_TYPES = ['http in']
@@ -109,6 +121,7 @@ let activeNodeId = null
 
 let runSequence = 0
 let _isLogging = false
+let _nestSpans = false
 let _rootPrefix = ''
 let _hasFlowNameInRoot = true
 let _timeout = 10
@@ -405,6 +418,7 @@ function createRun (tracer, msg, nodeDefinition, predecessorRunId) {
     rootSpan,
     ctx: trace.setSpan(context.active(), rootSpan),
     spans: new Map(),
+    spanContexts: new Map(),
     ignored: new Set(),
     entrySpans: new Set(),
     pending: 0,
@@ -551,6 +565,32 @@ function sweepRuns () {
 }
 
 /**
+ * Return the context a new span should be created in: the span of the node that sent the
+ * message, so the trace shows what triggered what, or the run span when there is no such node
+ * (the message came from outside the flow), when its span is already closed (an asynchronous
+ * hand off), or when the chain has grown too deep to be readable.
+ * @param {Run} run Run the new span belongs to
+ * @param {any} msg Message being delivered
+ * @param {string|undefined} sourceNodeId Node that sent the message, if any
+ * @returns {{ctx: Context, depth: number}}
+ */
+function getParentContext (run, msg, sourceNodeId) {
+  if (!_nestSpans || sourceNodeId === undefined) {
+    return { ctx: run.ctx, depth: 0 }
+  }
+  // The sending node may already have closed its span: it closes as soon as it has sent, while
+  // the wires after the first are delivered afterwards. A closed span is still a valid parent,
+  // so the lookup goes through the retained contexts rather than the open spans.
+  const direct = getSpanKey(msg._msgid, sourceNodeId)
+  const viaNodeState = getSpanKey(nodeStates.get(sourceNodeId)?.msgId, sourceNodeId)
+  const parent = run.spanContexts.get(direct) ?? run.spanContexts.get(viaNodeState)
+  if (parent === undefined || parent.depth >= MAX_NESTING_DEPTH) {
+    return { ctx: run.ctx, depth: 0 }
+  }
+  return parent
+}
+
+/**
  * Create a span for this node and message
  * @param {Tracer} tracer Tracer used for creating spans
  * @param {any} msg Complete message data
@@ -560,7 +600,7 @@ function sweepRuns () {
  * @param {boolean} isEntry Is the node emitting a message it never received?
  * @returns {Span|undefined} Created (or already open) span
  */
-function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, isEntry) {
+function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, isEntry, sourceNodeId) {
   try {
     if (msg === undefined || msg === null || msg._msgid === undefined) {
       return
@@ -575,10 +615,17 @@ function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, 
       return run.spans.get(openSpanKey) ?? fakeSpan
     }
     const spanKey = getSpanKey(msg._msgid, nodeDefinition.id)
+    const parent = getParentContext(run, msg, sourceNodeId)
 
     if (isNotTraced) {
       // remembered so the node is not looked at again, but never counted as pending
       run.ignored.add(spanKey)
+      if (_nestSpans) {
+        // an untraced node in the middle of a flow would otherwise cut the chain: whatever it
+        // sends to would fall back to the run span. It passes its own parent on instead, so the
+        // nesting skips over it to the nearest traced node.
+        run.spanContexts.set(spanKey, parent)
+      }
       return fakeSpan
     }
 
@@ -595,7 +642,7 @@ function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, 
         ...localAttributes,
       },
       kind: getSpanKind(nodeDefinition.type),
-    }, run.ctx)
+    }, parent.ctx)
     span._creationTimestamp = now
 
     if (nodeDefinition.type === 'http in') {
@@ -632,6 +679,12 @@ function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, 
     }
 
     run.spans.set(spanKey, span)
+    if (_nestSpans) {
+      run.spanContexts.set(spanKey, {
+        ctx: trace.setSpan(context.active(), span),
+        depth: parent.depth + 1,
+      })
+    }
     run.pending++
     run.updateTimestamp = now
     if (isEntry && !CORRELATED_ENTRY_TYPES.includes(nodeDefinition.type)) {
@@ -830,7 +883,7 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config)
 
     // get config
-    const { url, protocol, serviceName, rootPrefix, hasFlowNameInRoot, ignoredTypes, propagateHeadersTypes, isLogging, timeout, attributeMappings } = config
+    const { url, protocol, serviceName, rootPrefix, hasFlowNameInRoot, ignoredTypes, propagateHeadersTypes, isLogging, timeout, attributeMappings, nestSpans } = config
     const node = this
 
     // check config
@@ -852,6 +905,7 @@ module.exports = function (RED) {
     const ignoredTypesList = ignoredTypes.split(',').map(key => key.trim())
     const propagateHeadersTypesList = propagateHeadersTypes.split(',').map(key => key.trim())
     _isLogging = isLogging
+    _nestSpans = nestSpans === true
     _rootPrefix = rootPrefix
     _hasFlowNameInRoot = hasFlowNameInRoot
     _timeout = timeout * 1000
@@ -909,7 +963,7 @@ module.exports = function (RED) {
     RED.hooks.add('postDeliver.otel', (sendEvent) => {
       logEvent(node, '4.postDeliver', sendEvent)
       const { msg, source, destination } = sendEvent
-      const span = createSpan(tracer, msg, destination.node, [getRunId(msg), nodeStates.get(source.node.id)?.runId], ignoredTypesList.includes(destination.node.type), false)
+      const span = createSpan(tracer, msg, destination.node, [getRunId(msg), nodeStates.get(source.node.id)?.runId], ignoredTypesList.includes(destination.node.type), false, source.node.id)
       if (propagateHeadersTypesList.includes(destination.node.type)) {
         const run = resolveRun([getRunId(msg)])
         const output = {}

--- a/lib/opentelemetry-node.js
+++ b/lib/opentelemetry-node.js
@@ -32,9 +32,8 @@ const jmespath = require('jmespath')
  * @property {Span} rootSpan
  * @property {Context} ctx Context holding the root span, used as parent of every node span
  * @property {Map<string, Span>} spans Open node spans, keyed by `<msgId>#<nodeId>`
- * @property {Map<string, {ctx: Context, depth: number}>} spanContexts Context of every node span
- *   created in this run, kept after the span closes so a later wire still nests under it.
- *   Only filled when span nesting is switched on.
+ * @property {Map<string, {ctx: Context, depth: number}>} spanContexts Context of every node span of this run, kept
+ *   after the span closes so a later wire still nests under it. Only filled in nest spans mode
  * @property {Set<string>} ignored Span keys of nodes excluded from tracing
  * @property {Set<string>} entrySpans Span keys of nodes that emitted a message without receiving one
  * @property {number} pending Number of open node spans (the root ends when this reaches 0)
@@ -69,11 +68,8 @@ const ATTR_LINK_TYPE = 'node_red.link.type'
 const RUN_ID_PROPERTY = 'otelRootMsgId'
 
 /**
- * How deep the parent/child chain may go before a span is attached to the run span instead.
- * Only relevant when span nesting is switched on.
- * A flow that loops sends the message round the same nodes again, and each pass would otherwise
- * nest under the previous one, so a long loop would bury its last iteration under thousands of
- * levels that no trace viewer can show usefully.
+ * How deep the parent/child chain may go, in nest spans mode, before a span hangs off the local root span instead.
+ * A loop nests each pass under the previous one, so without this it buries its last iteration too deep to read.
  */
 const MAX_NESTING_DEPTH = 50
 
@@ -121,7 +117,7 @@ let activeNodeId = null
 
 let runSequence = 0
 let _isLogging = false
-let _nestSpans = false
+let _isNestSpansMode = false
 let _rootPrefix = ''
 let _hasFlowNameInRoot = true
 let _timeout = 10
@@ -565,22 +561,19 @@ function sweepRuns () {
 }
 
 /**
- * Return the context a new span should be created in: the span of the node that sent the
- * message, so the trace shows what triggered what, or the run span when there is no such node
- * (the message came from outside the flow), when its span is already closed (an asynchronous
- * hand off), or when the chain has grown too deep to be readable.
+ * Return the context a new span is created in: the span of the node that sent the message, or the local root span when
+ * there is no such node, when nest spans mode is off, or when the chain has grown too deep to read.
  * @param {Run} run Run the new span belongs to
  * @param {any} msg Message being delivered
  * @param {string|undefined} sourceNodeId Node that sent the message, if any
  * @returns {{ctx: Context, depth: number}}
  */
 function getParentContext (run, msg, sourceNodeId) {
-  if (!_nestSpans || sourceNodeId === undefined) {
+  if (!_isNestSpansMode || sourceNodeId === undefined) {
     return { ctx: run.ctx, depth: 0 }
   }
-  // The sending node may already have closed its span: it closes as soon as it has sent, while
-  // the wires after the first are delivered afterwards. A closed span is still a valid parent,
-  // so the lookup goes through the retained contexts rather than the open spans.
+  // the sender may have closed its span already, since it closes as soon as it has sent while later wires are
+  // delivered afterwards, and a closed span is still a valid parent
   const direct = getSpanKey(msg._msgid, sourceNodeId)
   const viaNodeState = getSpanKey(nodeStates.get(sourceNodeId)?.msgId, sourceNodeId)
   const parent = run.spanContexts.get(direct) ?? run.spanContexts.get(viaNodeState)
@@ -598,6 +591,7 @@ function getParentContext (run, msg, sourceNodeId) {
  * @param {Array<string|undefined>} candidateRunIds Candidate run identifiers, most trusted first
  * @param {boolean} isNotTraced Should the node be left untraced?
  * @param {boolean} isEntry Is the node emitting a message it never received?
+ * @param {string|undefined} [sourceNodeId] Node that sent the message, used in nest spans mode to make this span its child
  * @returns {Span|undefined} Created (or already open) span
  */
 function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, isEntry, sourceNodeId) {
@@ -620,10 +614,8 @@ function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, 
     if (isNotTraced) {
       // remembered so the node is not looked at again, but never counted as pending
       run.ignored.add(spanKey)
-      if (_nestSpans) {
-        // an untraced node in the middle of a flow would otherwise cut the chain: whatever it
-        // sends to would fall back to the run span. It passes its own parent on instead, so the
-        // nesting skips over it to the nearest traced node.
+      if (_isNestSpansMode) {
+        // an untraced node mid flow would cut the chain, so it passes its parent on and nesting skips over it
         run.spanContexts.set(spanKey, parent)
       }
       return fakeSpan
@@ -679,7 +671,7 @@ function createSpan (tracer, msg, nodeDefinition, candidateRunIds, isNotTraced, 
     }
 
     run.spans.set(spanKey, span)
-    if (_nestSpans) {
+    if (_isNestSpansMode) {
       run.spanContexts.set(spanKey, {
         ctx: trace.setSpan(context.active(), span),
         depth: parent.depth + 1,
@@ -883,7 +875,7 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config)
 
     // get config
-    const { url, protocol, serviceName, rootPrefix, hasFlowNameInRoot, ignoredTypes, propagateHeadersTypes, isLogging, timeout, attributeMappings, nestSpans } = config
+    const { url, protocol, serviceName, rootPrefix, hasFlowNameInRoot, ignoredTypes, propagateHeadersTypes, isLogging, timeout, attributeMappings, isNestSpansMode } = config
     const node = this
 
     // check config
@@ -905,7 +897,7 @@ module.exports = function (RED) {
     const ignoredTypesList = ignoredTypes.split(',').map(key => key.trim())
     const propagateHeadersTypesList = propagateHeadersTypes.split(',').map(key => key.trim())
     _isLogging = isLogging
-    _nestSpans = nestSpans === true
+    _isNestSpansMode = isNestSpansMode === true
     _rootPrefix = rootPrefix
     _hasFlowNameInRoot = hasFlowNameInRoot
     _timeout = timeout * 1000

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -53,7 +53,7 @@ const DEFAULT_CONFIG = {
   ignoredTypes: 'debug,catch',
   propagateHeadersTypes: '',
   isLogging: false,
-  nestSpans: false,
+  isNestSpansMode: false,
   timeout: 10,
   attributeMappings: [],
 }

--- a/test/helpers/mini-red.js
+++ b/test/helpers/mini-red.js
@@ -53,6 +53,7 @@ const DEFAULT_CONFIG = {
   ignoredTypes: 'debug,catch',
   propagateHeadersTypes: '',
   isLogging: false,
+  nestSpans: false,
   timeout: 10,
   attributeMappings: [],
 }

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -646,3 +646,167 @@ test('an entry node whose only wire is untraced still closes its run', async () 
   assert.equal(byName(spans, 'pump').length, 1)
   assert.equal(spans.filter((span) => span.attributes['node_red.span.incomplete']).length, 0)
 })
+
+/** Name of the span a given span hangs off, so the causal chain can be asserted directly */
+function parentNameOf (spans, span) {
+  const parent = spans.find((candidate) => candidate.spanContext().spanId === parentSpanIdOf(span))
+  return parent === undefined ? undefined : parent.name
+}
+
+test('span nesting is off by default, so every node span hangs off the run span', async () => {
+  const red = new MiniRed({ ignoredTypes: '' })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const first = red.node('n2', 'change', { name: 'first' })
+  const second = red.node('n3', 'change', { name: 'second' })
+  red.wire(inject, [first])
+  red.wire(first, [second])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  const root = rootOf(spans)
+  for (const span of spans.filter((span) => span !== root)) {
+    assert.equal(parentSpanIdOf(span), root.spanContext().spanId, `${span.name} must stay flat`)
+  }
+})
+
+test('a chain of nodes nests by what sent to what', async () => {
+  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const first = red.node('n2', 'change', { name: 'first' })
+  const second = red.node('n3', 'change', { name: 'second' })
+  const third = red.node('n4', 'change', { name: 'third' })
+  red.wire(inject, [first])
+  red.wire(first, [second])
+  red.wire(second, [third])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  const root = rootOf(spans)
+  assert.equal(parentNameOf(spans, byName(spans, 'start')[0]), root.name, 'the entry node hangs off the run')
+  assert.equal(parentNameOf(spans, byName(spans, 'first')[0]), 'start')
+  assert.equal(parentNameOf(spans, byName(spans, 'second')[0]), 'first')
+  assert.equal(parentNameOf(spans, byName(spans, 'third')[0]), 'second')
+})
+
+test('a fan out puts both branches under the node that sent them', async () => {
+  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const fork = red.node('n2', 'change', { name: 'fork' })
+  const left = red.node('n3', 'change', { name: 'left' })
+  const right = red.node('n4', 'change', { name: 'right' })
+  red.wire(inject, [fork])
+  red.wire(fork, [left, right])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1)
+  assert.equal(parentNameOf(spans, byName(spans, 'left')[0]), 'fork')
+  assert.equal(parentNameOf(spans, byName(spans, 'right')[0]), 'fork', 'the second wire nests too, though fork closed on the first')
+})
+
+test('a fan in gives each arriving message its own span under its own sender', async () => {
+  // a span has one parent, so a join is only ambiguous if it gets one span for N messages.
+  // It gets one per arrival, so each simply hangs off whichever branch delivered it.
+  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const fork = red.node('n2', 'change', { name: 'fork' })
+  const left = red.node('n3', 'change', { name: 'left' })
+  const right = red.node('n4', 'change', { name: 'right' })
+  const join = red.node('n5', 'join', { name: 'gather' })
+  red.wire(inject, [fork])
+  red.wire(fork, [[left], [right]]) // two outputs, one message each
+  red.wire(left, [join])
+  red.wire(right, [join])
+  red.on(fork, (msg, send, done) => {
+    const parts = ['l', 'r'].map((branch) => {
+      const part = { ...msg, payload: branch }
+      delete part._msgid
+      return part
+    })
+    send(parts)
+    done()
+  })
+  const gathered = []
+  red.on(join, (msg, send, done) => { gathered.push(msg.payload); done() })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  const joins = byName(spans, 'gather')
+  assert.equal(joins.length, 2, 'one span per message reaching the join')
+  assert.deepEqual(joins.map((span) => parentNameOf(spans, span)).sort(), ['left', 'right'])
+})
+
+test('a loop stops nesting once it gets too deep to read', async () => {
+  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const work = red.node('n2', 'function', { name: 'work' })
+  const again = red.node('n3', 'switch', { name: 'again?' })
+  const out = red.node('n4', 'change', { name: 'out' })
+  red.wire(inject, [work])
+  red.wire(work, [again])
+  red.wire(again, [[work], [out]])
+  const ROUNDS = 60 // deeper than MAX_NESTING_DEPTH, which is 50
+  red.on(work, (msg, send, done) => {
+    msg.n = (msg.n || 0) + 1
+    send(msg)
+    done()
+  })
+  red.on(again, (msg, send, done) => {
+    send(msg.n < ROUNDS ? [msg, null] : [null, msg])
+    done()
+  })
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(traceIdsOf(spans).size, 1, 'a loop is still one trace')
+  assert.equal(byName(spans, 'work').length, ROUNDS, 'one span per iteration')
+
+  // each pass nests under the previous one, so without a cap this chain would be ~120 deep
+  const byId = new Map(spans.map((span) => [span.spanContext().spanId, span]))
+  const depthOf = (span) => {
+    let depth = 0
+    let cursor = span
+    while (parentSpanIdOf(cursor) && byId.has(parentSpanIdOf(cursor))) {
+      cursor = byId.get(parentSpanIdOf(cursor))
+      depth++
+    }
+    return depth
+  }
+  const deepest = Math.max(...spans.map(depthOf))
+  assert.ok(deepest <= 51, `nesting must stop at the cap, reached ${deepest}`)
+  assert.ok(deepest > 10, 'shallow iterations must still nest, otherwise the cap is doing nothing')
+
+  // past the cap a span restarts from the run span rather than burying itself further
+  const root = rootOf(spans)
+  const rehomed = spans.filter((span) => parentNameOf(spans, span) === root.name && span.name !== 'start')
+  assert.ok(rehomed.length > 0, 'something past the cap must fall back to the run span')
+})
+
+test('an untraced node in the middle of a flow does not cut the chain', async () => {
+  // `catch` is untraced by default and can sit mid flow, unlike `debug` which is usually a leaf
+  const red = new MiniRed({ ignoredTypes: 'catch', nestSpans: true })
+  const inject = red.node('n1', 'inject', { name: 'start' })
+  const skipped = red.node('n2', 'catch', { name: 'not traced' })
+  const after = red.node('n3', 'change', { name: 'after' })
+  red.wire(inject, [skipped])
+  red.wire(skipped, [after])
+
+  red.send(inject, { payload: 1 })
+  red.run()
+  const spans = await red.stop()
+
+  assert.equal(byName(spans, 'not traced').length, 0, 'the untraced node gets no span')
+  // without passing the parent through, "after" would fall back to the run span
+  assert.equal(parentNameOf(spans, byName(spans, 'after')[0]), 'start',
+    'the chain skips the untraced node to the nearest traced one')
+})

--- a/test/trace-lifecycle.test.js
+++ b/test/trace-lifecycle.test.js
@@ -653,7 +653,7 @@ function parentNameOf (spans, span) {
   return parent === undefined ? undefined : parent.name
 }
 
-test('span nesting is off by default, so every node span hangs off the run span', async () => {
+test('span nesting is off by default, so every node span hangs off the local root span', async () => {
   const red = new MiniRed({ ignoredTypes: '' })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const first = red.node('n2', 'change', { name: 'first' })
@@ -672,7 +672,7 @@ test('span nesting is off by default, so every node span hangs off the run span'
 })
 
 test('a chain of nodes nests by what sent to what', async () => {
-  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const red = new MiniRed({ ignoredTypes: '', isNestSpansMode: true })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const first = red.node('n2', 'change', { name: 'first' })
   const second = red.node('n3', 'change', { name: 'second' })
@@ -693,7 +693,7 @@ test('a chain of nodes nests by what sent to what', async () => {
 })
 
 test('a fan out puts both branches under the node that sent them', async () => {
-  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const red = new MiniRed({ ignoredTypes: '', isNestSpansMode: true })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const fork = red.node('n2', 'change', { name: 'fork' })
   const left = red.node('n3', 'change', { name: 'left' })
@@ -713,7 +713,7 @@ test('a fan out puts both branches under the node that sent them', async () => {
 test('a fan in gives each arriving message its own span under its own sender', async () => {
   // a span has one parent, so a join is only ambiguous if it gets one span for N messages.
   // It gets one per arrival, so each simply hangs off whichever branch delivered it.
-  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const red = new MiniRed({ ignoredTypes: '', isNestSpansMode: true })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const fork = red.node('n2', 'change', { name: 'fork' })
   const left = red.node('n3', 'change', { name: 'left' })
@@ -745,7 +745,7 @@ test('a fan in gives each arriving message its own span under its own sender', a
 })
 
 test('a loop stops nesting once it gets too deep to read', async () => {
-  const red = new MiniRed({ ignoredTypes: '', nestSpans: true })
+  const red = new MiniRed({ ignoredTypes: '', isNestSpansMode: true })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const work = red.node('n2', 'function', { name: 'work' })
   const again = red.node('n3', 'switch', { name: 'again?' })
@@ -786,15 +786,15 @@ test('a loop stops nesting once it gets too deep to read', async () => {
   assert.ok(deepest <= 51, `nesting must stop at the cap, reached ${deepest}`)
   assert.ok(deepest > 10, 'shallow iterations must still nest, otherwise the cap is doing nothing')
 
-  // past the cap a span restarts from the run span rather than burying itself further
+  // past the cap a span restarts from the local root span rather than burying itself further
   const root = rootOf(spans)
   const rehomed = spans.filter((span) => parentNameOf(spans, span) === root.name && span.name !== 'start')
-  assert.ok(rehomed.length > 0, 'something past the cap must fall back to the run span')
+  assert.ok(rehomed.length > 0, 'something past the cap must fall back to the local root span')
 })
 
 test('an untraced node in the middle of a flow does not cut the chain', async () => {
   // `catch` is untraced by default and can sit mid flow, unlike `debug` which is usually a leaf
-  const red = new MiniRed({ ignoredTypes: 'catch', nestSpans: true })
+  const red = new MiniRed({ ignoredTypes: 'catch', isNestSpansMode: true })
   const inject = red.node('n1', 'inject', { name: 'start' })
   const skipped = red.node('n2', 'catch', { name: 'not traced' })
   const after = red.node('n3', 'change', { name: 'after' })
@@ -806,7 +806,7 @@ test('an untraced node in the middle of a flow does not cut the chain', async ()
   const spans = await red.stop()
 
   assert.equal(byName(spans, 'not traced').length, 0, 'the untraced node gets no span')
-  // without passing the parent through, "after" would fall back to the run span
+  // without passing the parent through, "after" would fall back to the local root span
   assert.equal(parentNameOf(spans, byName(spans, 'after')[0]), 'start',
     'the chain skips the untraced node to the nearest traced one')
 })


### PR DESCRIPTION
Implements the `nest spans` option agreed in #36.

Every node span is a child of the run span, which reads well as a timeline but leaves out something the runtime knows: `postDeliver` carries both the sending and the receiving node, so the edge exists and is discarded. A trace cannot then be turned back into the path a message took.

With the option on, a node span is a child of the span of the node that sent it the message, and only the node that started the run hangs off the run span. Off, which is the default, nothing changes.

**Cost when off is nothing.** Nothing is stored and no lookup happens, so the default path measures the same as today. 20000 runs of a four node flow, three runs each, median us per span, baseline is master at 3914433:

| | master | this PR, unticked | this PR, ticked |
| --- | --- | --- | --- |
| CPU | 3.73 | 3.70 | 4.10 |

Four things worth knowing about the implementation:

- the context of each span is kept for the life of the run rather than only while the span is open, since a node closes its span as soon as it has sent while the wires after the first are delivered afterwards, and a closed span is still a valid parent. Without this only the first wire of a fan out nested correctly,
- a fan in needs no special handling: a join gets one span per arriving message, so each hangs off whichever branch delivered it and no span ever needs two parents,
- an untraced node passes its parent through, so a `catch` in the middle of a flow does not cut the chain,
- a loop grows the chain by two levels per pass, so a chain deeper than 50 restarts from the run span. Without that a long loop buries its last iteration under thousands of levels.

Six tests added: one asserting the default stays flat, and five covering a chain, a fan out, a fan in, a deep loop and the untraced node case. The existing tests are unchanged, since the default behaviour is unchanged. `npm test` green (38), `npm run lint` clean.
